### PR TITLE
http server and manager modification

### DIFF
--- a/sisyphus/block.py
+++ b/sisyphus/block.py
@@ -44,6 +44,10 @@ class Block(object):
         else:
             return self.children
 
+    def get_sub_blocks(self):
+         return [child for child in self.children
+                if (isinstance(child, Block) and not child.empty())]
+
     def empty(self):
         return not bool(self.filtered_children())
 

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -172,6 +172,8 @@ WAIT_PERIOD_MTIME_OF_INPUTS = 60
 
 #: set true to automatically clean jobs in error state and retry
 CLEAR_ERROR = False
+
+PRINT_ERROR = True
 #: Print detailed log of that many jobs in error state
 PRINT_ERROR_TASKS = 1
 #: Print that many last lines of error state log file

--- a/sisyphus/http_server.py
+++ b/sisyphus/http_server.py
@@ -269,6 +269,7 @@ def visualize(block_id):
     url_prefix = '/vis/' + block_id
 
     if parent is None:
+        items += all_root_blocks[0].get_sub_blocks()
         return render_template("vis_overview.html", items=items)
     else:
         dot_file = visualize_block(parent, g_sis_engine, url_prefix)

--- a/sisyphus/http_server.py
+++ b/sisyphus/http_server.py
@@ -236,6 +236,7 @@ def show_job_informations(sis_id):
                                tasks=tasks,
                                kwargs=object_to_html(job._sis_kwargs),
                                inputs=object_to_html(job._sis_inputs),
+                               outputs=object_to_html(job._sis_outputs),
                                info=info,
                                rqmt=rqmt,
                                task_logs=task_logs

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -237,7 +237,7 @@ class Manager(threading.Thread):
                              gs.STATE_RETRY_ERROR,
                              gs.STATE_ERROR]:
                     logging.error(info_string)
-                    if state == gs.STATE_ERROR:
+                    if state == gs.STATE_ERROR and gs.PRINT_ERROR:
                         job._sis_print_error(gs.PRINT_ERROR_TASKS,
                                              gs.PRINT_ERROR_LINES)
                 elif state in [gs.STATE_INTERRUPTED, gs.STATE_UNKNOWN]:

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -233,6 +233,9 @@ class Manager(threading.Thread):
                 else:
                     info_string = '%s: %s' % (state, job)
 
+                if hasattr(job, "get_vis_name") and job.get_vis_name() is not None:
+                    info_string += " [%s]" % job.get_vis_name()
+
                 if state in [gs.STATE_INPUT_MISSING,
                              gs.STATE_RETRY_ERROR,
                              gs.STATE_ERROR]:

--- a/sisyphus/templates/details.html
+++ b/sisyphus/templates/details.html
@@ -63,6 +63,8 @@ Arguments: <br>
 {{ kwargs|safe }}
 Inputs: <br>
 {{ inputs|safe }}
+Outputs: <br>
+{{ outputs|safe }}
 {% if info %}
 Informations: <br>
 {{ info|safe }}


### PR DESCRIPTION
The _sis_vis_name attribute of a "Job" class can now be used to show custom names in the manager view.

The printing of job-errors inside the manager view can be turned off.


When encapsulating jobs with a sub_block, e.g.

`block = tk.sub_block("some_block")`
`with block:`
`some job-calls....`

This blocks graph can be rendered in the "Visualize Dependency Graph" section of the http server view.

Additionally, the http job view now displays job outputs.