### PR TITLE
added manager callback function to display dynamic job information

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -1051,6 +1051,14 @@ class Job(object, metaclass=JobSingleton):
         to be displayed on the web interface """
         pass
 
+    def manager_callback(self):
+        """ Is executed each time the job is displayed in the manager,
+        can be used to print live information about the job
+        :return: string to be displayed or None if not available
+        :rtype: str
+        """
+        return None
+
     @classmethod
     def hash(cls, parsed_args):
         """

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -1048,16 +1048,11 @@ class Job(object, metaclass=JobSingleton):
 
     def info(self):
         """ Returns information about the currently running job
-        to be displayed on the web interface """
-        pass
-
-    def manager_callback(self):
-        """ Is executed each time the job is displayed in the manager,
-        can be used to print live information about the job
+        to be displayed on the web interface and the manager view
         :return: string to be displayed or None if not available
         :rtype: str
         """
-        return None
+        pass
 
     @classmethod
     def hash(cls, parsed_args):

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -253,6 +253,11 @@ class Manager(threading.Thread):
                 if hasattr(job, "get_vis_name") and job.get_vis_name() is not None:
                     info_string += " [%s]" % job.get_vis_name()
 
+                if hasattr(job, "manager_callback"):
+                    job_manager_callback_string = job.manager_callback()
+                    if job_manager_callback_string is not None:
+                        info_string += " {%s} " % job_manager_callback_string
+
                 if state in [gs.STATE_INPUT_MISSING,
                              gs.STATE_RETRY_ERROR,
                              gs.STATE_ERROR]:

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -253,10 +253,10 @@ class Manager(threading.Thread):
                 if hasattr(job, "get_vis_name") and job.get_vis_name() is not None:
                     info_string += " [%s]" % job.get_vis_name()
 
-                if hasattr(job, "manager_callback"):
-                    job_manager_callback_string = job.manager_callback()
-                    if job_manager_callback_string is not None:
-                        info_string += " {%s} " % job_manager_callback_string
+                if hasattr(job, "info"):
+                    job_manager_info_string = job.info()
+                    if job_manager_info_string is not None:
+                        info_string += " {%s} " % job_manager_info_string
 
                 if state in [gs.STATE_INPUT_MISSING,
                              gs.STATE_RETRY_ERROR,


### PR DESCRIPTION
There was a request to add dynamic information into the manager view. You can override the function to provide additional dynamic information about the job, which can e.g. be the perplexity of a running model training job.