### PR TITLE
Fixed issue with argument length during the directory size computation

### DIFF
--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -516,13 +516,14 @@ def cleaner(clean_job_dir=False, clean_work_dir=False, mode='dryrun', keep_value
             for i in tmp:
                 print(i)
         else:
-            # TODO: accumulate results of each run, or fix the issue otherwise
-            for i in range(0, len(tmp), 2500):
-                command = 'du -sch %s' % (' '.join(tmp[i:i+2500]))
+            with mktemp() as tmp_file:
+                with open(tmp_file, "w") as f:
+                    for directory in dirs:
+                        f.write(directory + "\x00")
+                command = 'du -sch --files0-from=%s' % (tmp_file,)
                 p = os.popen(command)
                 print(p.read())
                 p.close()
-            logging.warning("Parameter limit exceeded, size is not displayed correctly")
         if not just_list:
             if mode == 'dryrun':
                 input_var = 'y'


### PR DESCRIPTION
By storing the list of directories in a temporary file, the number of directories no longer influences the command length. 