### PR TITLE
fixed missing path separator for tempdir paths not ending with a slash

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -243,7 +243,7 @@ DEFAULT_ENVIRONMENT_SET = {'LANG': 'en_US.UTF-8',
                                              '/snap/bin']),
                            'SHELL': '/bin/bash'}
 #: Directory used by tk.mktemp
-TMP_PREFIX = os.environ.get('TMPDIR', '/tmp/') + 'sis_'
+TMP_PREFIX = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'sis_')
 
 # Visualization
 #: For http visualization, list job input as common input if it is share between more then X*(total jobs) jobs


### PR DESCRIPTION
Miguel found this new bug, as TMPDIR defaults to "/var/tmp" in our bashrc