### PR TITLE
added optional stacktrace to jobs, can be used in console

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -254,7 +254,7 @@ VIS_ABSOLUTE_MERGE_THRESHOLD = 5
 SHOW_VIS_NAME_IN_MANAGER = True
 
 # Add stacktrace information with specified depth, 0 for deactivation
-JOB_ADD_STACKTRACE_WITH_DEPTH = 1
+JOB_ADD_STACKTRACE_WITH_DEPTH = 0
 
 # Internal functions
 def update_global_settings_from_text(text, filename):

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -253,6 +253,9 @@ VIS_ABSOLUTE_MERGE_THRESHOLD = 5
 
 SHOW_VIS_NAME_IN_MANAGER = True
 
+# Add stacktrace information with specified depth, 0 for deactivation
+JOB_ADD_STACKTRACE_WITH_DEPTH = 1
+
 # Internal functions
 def update_global_settings_from_text(text, filename):
     """

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -221,9 +221,6 @@ USE_SIGNAL_HANDLERS = False
 #: Automatically set all input given to __init__  as attributes of the created job.
 #: Disabled by default since it tends to confuse new users reading the code.
 AUTO_SET_JOB_INIT_ATTRIBUTES = False
-#: Save traceback when a job is created to allow easier debugging. Disabled by default since it increases start up time
-LOG_TRACEBACKS = False
-
 
 # Job environment
 #: Remove all environment variables to ensure the same environment between different users
@@ -253,7 +250,7 @@ VIS_ABSOLUTE_MERGE_THRESHOLD = 5
 
 SHOW_VIS_NAME_IN_MANAGER = True
 
-# Add stacktrace information with specified depth, 0 for deactivation
+# Add stacktrace information with specified depth, 0 for deactivation, None or -1 for full stack
 JOB_ADD_STACKTRACE_WITH_DEPTH = 0
 
 # Internal functions

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -127,6 +127,13 @@ class JobSingleton(type):
         # Update alias prefixes
         job._sis_alias_prefixes.add(gs.ALIAS_AND_OUTPUT_SUBDIR)
 
+        # add stacktrace information
+        stack_depth = gs.JOB_ADD_STACKTRACE_WITH_DEPTH
+        if stack_depth > 0:
+            # add +1 for the traceback command itself, and remove it later
+            stacktrace = traceback.extract_stack(limit=(stack_depth+1))[:-1]
+            job._sis_stacktrace.append(stacktrace)
+
         return job
 
     def state_init(cls, state):
@@ -212,6 +219,8 @@ class Job(object, metaclass=JobSingleton):
         self._sis_quiet = False
         self._sis_cleanable_cache = False
         self._sis_needed_for_which_targets = set()
+
+        self._sis_stacktrace = []
 
     # Functions directly used to run the job
     def _sis_setup_directory(self):

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -119,19 +119,14 @@ class JobSingleton(type):
                 b.add_job(job)
                 job._sis_add_block(b)
 
-        # Log traceback for debugging
-        if gs.LOG_TRACEBACKS:
-            # 6:-1 to remove Sisyphus related traces
-            job._sis_tracebacks.add(tuple(traceback.format_stack()[6:-1]))
-
         # Update alias prefixes
         job._sis_alias_prefixes.add(gs.ALIAS_AND_OUTPUT_SUBDIR)
 
-        # add stacktrace information
-        stack_depth = gs.JOB_ADD_STACKTRACE_WITH_DEPTH
-        if stack_depth > 0:
+        # add stacktrace information, if set to None or -1 use full stack
+        stack_depth = gs.JOB_ADD_STACKTRACE_WITH_DEPTH + 1 if gs.JOB_ADD_STACKTRACE_WITH_DEPTH >= 0 else None
+        if stack_depth > 1 or None:
             # add +1 for the traceback command itself, and remove it later
-            stacktrace = traceback.extract_stack(limit=(stack_depth+1))[:-1]
+            stacktrace = traceback.extract_stack(limit=stack_depth)[:-1]
             job._sis_stacktrace.append(stacktrace)
 
         return job
@@ -191,8 +186,6 @@ class Job(object, metaclass=JobSingleton):
         self._sis_keep_value = None
 
         self._sis_blocks = set()
-        self._sis_tracebacks = set()
-
         self._sis_kwargs = parsed_args
         self._sis_task_rqmt_overwrite = {}
 


### PR DESCRIPTION
I thought this to be a very useful thing, it can be used to determine where a job was created.
Also, you can find all jobs belonging to a single call, e.g:

```
for job in j:
    first_st = job._sis_stacktrace[0][0]
    if first_st[0] == "/u/rossenbach/experiments/switchboard_test/config/E2ESystem.py" and first_st[1] == 229:
        print(job)
```

will list all jobs that are created in E2ESystem.py line 229:

```
225: j = CRNNSprintSearchJob(search_csp=self.csp[search_corpus],
226:                                feature_flow=self.feature_flows[feature_corpus][feature_flow],
227:                                crnn_config=crnn_config,
228:                                num_classes=self.functor_value(num_classes),
229:                                **kwargs)
```