### PR TITLE
Enable priorities using qsub job_share

### DIFF
--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -149,6 +149,10 @@ class SonOfGridEngine(EngineBase):
 
         out.append('-l')
         out.append('h_rt=%s' % task_time)
+
+        out.append('-js')
+        out.append('%s' % rqmt.get('priority', 50))
+
         qsub_args = rqmt.get('qsub_args', [])
         if isinstance(qsub_args, str):
             qsub_args = qsub_args.split()


### PR DESCRIPTION
To allow assigning user-internal priorities to jobs, a `priority` option was added to the job requirements. It is passed to qsub's job_share option. As job_share is an unsigned integer with a default value of 0 and we want to allow decreasing a job's priority relative to other jobs, the default value in the job requirements is set to 50.