### PR TITLE
Limited number of acquired locks

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -143,6 +143,10 @@ GRAPH_WORKER = 16
 #: How many threads are used to setup the job directory and submit jobs
 MANAGER_SUBMIT_WORKER = 10
 
+#: How many locks can be used by all jobs (one lock per job). If there are more jobs than locks, locks are reused
+#: This could lead to a slowdown, but the number of locks per process is limited
+JOB_MAX_NUMBER_OF_LOCKS = 60000
+
 #: Default function to hash jobs and objects
 SIS_HASH = sisyphus.hash.short_hash
 


### PR DESCRIPTION
The number of locks that can be acquired is limited by some system setting. I'm not certain which one it is, but it can be tested by this program:

```
import multiprocessing

a = []
try:
  for i in range(100000):
    a.append(multiprocessing.Lock())
  print("Success")
except:
  print("Error at lock number %d" % i)
```

For me, this returns `Error at lock number 65270`.

If every job gets its own lock, this means that I cannot have more than about 65000 jobs in my tree. I usually don't, but if I want to start the cleaner, I have to include every experiment I've ever started. This led to the error message `OSError: [Errno 12] Cannot allocate memory` when no more locks could be acquired.

This PR fixes this issue by reusing the locks once a configurable threshold is reached.