### PR TITLE
Avoid f-strings to ensure compatibility to python versions < 3.6

### DIFF
--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -1029,9 +1029,9 @@ def run(obj):
 
         # Stop loop if no jobs can be run
         if not todo_list:
-            logging.error(f"Can not finish computation of {obj} some jobs are blockeding")
+            logging.error("Can not finish computation of %s some jobs are blockeding" % obj)
             for k, v in temp_graph.get_jobs_by_status(skip_finished=True):
-                logging.error(f"Jobs in state {k} are: {v}")
+                logging.error("Jobs in state %s are: %s" % (k, v))
             break
 
         # Actually run the jobs


### PR DESCRIPTION
Commit ec7de9b1eb7d04dc38d48f0e8628ea716e50026c introduced f-strings, which are not supported for python versions older than 3.6. By using %-formatting instead, we don't lose support for older python versions.