### PR TITLE
Added clear option for interrupted jobs

### DIFF
--- a/sisyphus/__main__.py
+++ b/sisyphus/__main__.py
@@ -50,9 +50,13 @@ def main():
     parser_manager.set_defaults(func=manager)
     parser_manager.add_argument("-r", dest="run", default=False,
                                 action='store_true', help="Run the given task")
-    parser_manager.add_argument("-co", dest="clear_once", action="store_true",
+    parser_manager.add_argument("-co", dest="clear_errors_once", action="store_true",
                                 default=False,
                                 help="Move jobs aside that are in an error "
+                                     "state when the manager runs the first time")
+    parser_manager.add_argument("-cio", dest="clear_interrupts_once", action="store_true",
+                                default=False,
+                                help="Move jobs aside that are in an interrupt "
                                      "state when the manager runs the first time")
     parser_manager.add_argument("-io", dest="ignore_once", action="store_true",
                                 default=False,

--- a/sisyphus/notebook.py
+++ b/sisyphus/notebook.py
@@ -25,7 +25,7 @@ manager = sisyphus.manager.Manager(sis_graph=sis_graph,
                                    job_engine=job_engine,
                                    callbacks={},
                                    link_outputs=False,
-                                   clear_once=False,
+                                   clear_errors_once=False,
                                    start_computations=True,
                                    auto_print_stat_overview=True)
 

--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -617,7 +617,7 @@ def start_manager(job_engine=None, start_computations=False):
     return sisyphus.manager.Manager(sis_graph=sis_graph,
                                     job_engine=job_engine,
                                     link_outputs=False,
-                                    clear_once=False,
+                                    clear_errors_once=False,
                                     start_computations=start_computations,
                                     auto_print_stat_overview=False)
 


### PR DESCRIPTION
I think there should be a "clear" option for interrupted jobs that don't continue on their own.
As I didn't find anything, I implemented it in the same way it's done for error jobs.
 