### PR TITLE
Made _sis_delete() compatible with symlinks

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -720,7 +720,10 @@ class Job(object, metaclass=JobSingleton):
         path = self._sis_path()
         logging.info('Delete: %s' % path)
         try:
-            shutil.rmtree(path)
+            if os.path.islink(path):
+                os.unlink(path)
+            else:
+                shutil.rmtree(path)
         except FileNotFoundError:
             logging.warning('File not Found: %s' % path)
 


### PR DESCRIPTION
Previously `_sis_delete()` would throw an error for symlinks (as it tries to remove them via `shutil.rmtree(path)`.
Fixed this problem by adding a case distinction.