### PR TITLE
do not stop remove on error

### DIFF
--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -582,7 +582,10 @@ def cleaner(clean_job_dir: bool=False,
                         if os.path.islink(k):
                             os.unlink(k)
                         else:
-                            shutil.rmtree(k)
+                            try:
+                                shutil.rmtree(k)
+                            except OSError as error:
+                                print(error)
                     else:
                         assert False
             else:


### PR DESCRIPTION
There are sometimes errors during removal (etc open folder or some leftover .nfs files), but I do not want the removal to stop completely.