### PR TITLE
added error message for parameter bug

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -121,7 +121,11 @@ class JobSingleton(type):
                 job._sis_add_block(b)
 
         # Update alias prefixes
-        job._sis_alias_prefixes.add(gs.ALIAS_AND_OUTPUT_SUBDIR)
+        try:
+            job._sis_alias_prefixes.add(gs.ALIAS_AND_OUTPUT_SUBDIR)
+        except Exception as e:
+            assert False, ("An empty Job was loaded, this can happen if classes were passed as parameters that could"
+                           "not be pickled properly")
 
         # add stacktrace information, if set to None or -1 use full stack
         stack_depth = gs.JOB_ADD_STACKTRACE_WITH_DEPTH + 1 if gs.JOB_ADD_STACKTRACE_WITH_DEPTH >= 0 else None


### PR DESCRIPTION
I had a strange bug, where opening the pickle file would result in the whole config to be loaded again, resulting conflicting emtpy jobs. It took some time until I could find a wrong parameter as cause (it was a wrong class added to a dict which was part of a correct class passed as parameter, the inputs are unfortunately quite complicated sometimes).