### PR TITLE
make call to h_fsize non hard-coded

### DIFF
--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -148,16 +148,15 @@ class SonOfGridEngine(EngineBase):
         else:
             out.append('h_rss=%s' % mem)
 
-        if "file_size" in rqmt:
-            try:
-                filesize = "%iG" % math.ceil(float(rqmt['file_size']))
-            except ValueError:
-                filesize = rqmt.get('file_size', "50G")
-        else:
-            file_size = "50G"
+        try:
+            file_size = "%iG" % math.ceil(float(rqmt['file_size']))
+        except (ValueError, KeyError):
+            # If a different default value is wanted it can be overwritten by adding
+            # 'file_size' to the default_rqmt of this engine.
+            file_size = rqmt.get('file_size', "50G")
 
         out.append('-l')
-        out.append('f_fsize=%s' % filesize)
+        out.append('h_fsize=%s' % file_size)
 
         out.append('-l')
         out.append('gpu=%s' % rqmt.get('gpu', 0))

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -148,6 +148,17 @@ class SonOfGridEngine(EngineBase):
         else:
             out.append('h_rss=%s' % mem)
 
+        if "file_size" in rqmt:
+            try:
+                filesize = "%iG" % math.ceil(float(rqmt['file_size']))
+            except ValueError:
+                filesize = rqmt.get('file_size', "50G")
+        else:
+            file_size = "50G"
+
+        out.append('-l')
+        out.append('f_fsize=%s' % filesize)
+
         out.append('-l')
         out.append('gpu=%s' % rqmt.get('gpu', 0))
 
@@ -227,8 +238,6 @@ class SonOfGridEngine(EngineBase):
             'y',
             '-o',
             logpath,
-            '-l',
-            'h_fsize=50G',
             '-S',
             '/bin/bash',
             '-m',


### PR DESCRIPTION
Current situation: h_fsize in the SGE Engine is hardcoded to 50GB
Change: indroduction of a new key for the requirements dict: "file_size"
Effect: h_fsize can be set by user. The default value remains at 50GB