### PR TITLE
add has_memory_resource parameter for slurm

### DIFF
--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -42,11 +42,12 @@ def try_to_multiply(y, x, backup_value=None):
 
 class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
 
-    def __init__(self, default_rqmt, gateway=None, auto_clean_eqw=True, ignore_jobs=[]):
+    def __init__(self, default_rqmt, gateway=None, has_memory_resource=True, auto_clean_eqw=True, ignore_jobs=[]):
         """
 
         :param dict default_rqmt: dictionary with the default rqmts
         :param str gateway: ssh to that node and run all sge commands there
+        :param bool has_memory_resource: Set to False if the Slurm setup was not configured for managing memory
         :param bool auto_clean_eqw: if True jobs in eqw will be set back to qw automatically
         :param list[str] ignore_jobs: list of job ids that will be ignored during status updates.
                                       Useful if a job is stuck inside of Slurm and can not be deleted.
@@ -55,6 +56,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         self._task_info_cache_last_update = 0
         self.gateway = gateway
         self.default_rqmt = default_rqmt
+        self.has_memory_resource = has_memory_resource
         self.auto_clean_eqw = auto_clean_eqw
         self.ignore_jobs = ignore_jobs
 
@@ -115,12 +117,13 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
 
     def options(self, rqmt):
         out = []
-        try:
-            mem = "%iG" % math.ceil(float(rqmt['mem']))
-        except ValueError:
-            mem = rqmt['mem']
+        if self.has_memory_resource:
+          try:
+              mem = "%iG" % math.ceil(float(rqmt['mem']))
+          except ValueError:
+              mem = rqmt['mem']
 
-        out.append('--mem-per-cpu=%s' % mem)
+          out.append('--mem-per-cpu=%s' % mem)
 
         if 'rss' in rqmt:
             pass  # there is no option in SLURM?


### PR DESCRIPTION
On local Slurm setups you might want not configure memory as a resource, but Slurm will give an error if you try to assign jobs memory when not configured.