### PR TITLE
add workflow diagramm for the example in the documentation using mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Sisyphus requires a Python >=3.5 installation with the following additional libr
   Optional to compile documentation:
 
     pip3 install Sphinx
+    pip3 install sphinxcontrib-mermaid
 
   Optional if virtual file system should be used:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinxcontrib.mermaid'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,33 @@ Sisyphus requires a Python 3.5 installation with the following additional librar
 QuickStart
 ==========
 To run sisyphus you need to setup an experiment folder that contains all needed files (See :ref:`sec-structure`).
-An example directory is given in the example folder. To start this toy setup run::
+
+An example directory is given in the example folder.
+It runs the workflow presented by the diagramm below
+
+.. mermaid::
+
+  graph TD;
+      start[Start]:::startclass -- data/5lines.txt --> Splitter
+      Splitter -- out_path --> Parallel
+      Parallel -- out_path: path, check_block --> Simple
+      Parallel -- out --> result[Finish]:::resultclass
+      classDef resultclass fill:#f66;
+      classDef startclass fill:#63e06d;
+      PipeLine -- merger.gz, score --> Parallel
+
+      subgraph pipeline
+      Merger -- merger.gz  --> PipeLine
+      FinishedParts -. out1.gz --> SimplePart1 -.-> Merger
+      FinishedParts -. out2.gz  --> SimplePart2 -.-> Merger
+      FinishedParts -. out3.gz  --> SimplePart3 -.-> Merger
+      Arguments -- out.gz --> FinishedParts
+      Simple -- out.gz --> Arguments
+      Arguments -- out.gz  --> CheckState
+      CheckState -- score --> PipeLine
+    end
+
+To start this toy setup run::
 
     ../sis manager
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psutil
 ipython
-
+sphinxcontrib-mermaid


### PR DESCRIPTION
Maybe adding mermaid diagrams for sphinx could improve documentation?

Here I add a diagram for the example. It is still far away from being clear what the example is supposed to do. I spent quite some time and still feel unsure about it.

It feels like the example is forcefully using as many features as possible. While maybe logical, it ends up being very complicated for a novice to get an idea of what sisyphus is supposed to do.

Maybe smaller examples that aim to show only certain features would make more sense. The users can put them together on their own.