### PR TITLE
allow recipe module outside `recipe` package

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -88,8 +88,10 @@ class JobSingleton(type):
         sis_hash = cls._sis_hash_static(parsed_args)
         module_name = cls.__module__
         recipe_prefix = gs.RECIPE_PREFIX + '.'
-        assert module_name.startswith(recipe_prefix)
-        sis_name = os.path.join(module_name[len(recipe_prefix):].replace('.', os.path.sep), cls.__name__)
+        if module_name.startswith(recipe_prefix):
+          sis_name = os.path.join(module_name[len(recipe_prefix):].replace('.', os.path.sep), cls.__name__)
+        else:
+          sis_name = os.path.join(module_name.replace('.', os.path.sep), cls.__name__)
         sis_id = "%s.%s" % (sis_name, sis_hash)
 
         # Update tags


### PR DESCRIPTION
Via: https://github.com/rwth-i6/i6_core/issues/11

Suggested by @JackTemaki .
