### PR TITLE
Allow more flexibility for recipe loading

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -165,11 +165,11 @@ MAX_SUBMIT_RETRIES = 3
 #: Default function to hash jobs and objects
 SIS_HASH = sisyphus.hash.short_hash
 
-#: Path to the config directory, not including the directory name 'config'
-CONFIG_PATH = '.'
-
-#: Path to the recipe directory, not including the directory name 'recipe'
-RECIPE_PATH = '.'
+#: List of paths searched for loading config and recipe files. The module name should be part of the path e.g.:
+#: adding 'config' will cause Sisyphus to the current directory for a folder named config to load modules starting
+#: with config, other python files in the current directory will be ignored.
+#: If the path ends with '/' everything inside it will be loaded, similar to adding it to PYTHONPATH.
+IMPORT_PATHS = ['config', 'recipe']
 
 #: The work directory
 WORK_DIR = 'work'

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -88,8 +88,11 @@ class JobSingleton(type):
         sis_hash = cls._sis_hash_static(parsed_args)
         module_name = cls.__module__
         recipe_prefix = gs.RECIPE_PREFIX + '.'
-        assert module_name.startswith(recipe_prefix)
-        sis_name = os.path.join(module_name[len(recipe_prefix):].replace('.', os.path.sep), cls.__name__)
+        if module_name.startswith(recipe_prefix):
+            sis_name = module_name[len(recipe_prefix):]
+        else:
+            sis_name = module_name
+        sis_name = os.path.join(sis_name.replace('.', os.path.sep), cls.__name__)
         sis_id = "%s.%s" % (sis_name, sis_hash)
 
         # Update tags

--- a/sisyphus/loader.py
+++ b/sisyphus/loader.py
@@ -222,10 +222,12 @@ class RecipeFinder:
 
             if not module_prefix or fullname == module_prefix or fullname.startswith(module_prefix + '.'):
                 if path is None:
-                    search_path = os.path.abspath(module_dir)
+                    search_path = [os.path.abspath(module_dir)]
                 elif isinstance(path, str):
-                    search_path = os.path.abspath(os.path.join(module_dir, path))
-                spec = PathFinder.find_spec(fullname, [search_path], target)
+                    search_path = [os.path.abspath(os.path.join(module_dir, path))]
+                else:
+                    search_path = path
+                spec = PathFinder.find_spec(fullname, search_path, target)
                 if spec:
                     return spec
 

--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -228,6 +228,8 @@ def setup_path(package: str) -> RelPath:
     assert (getattr(module, '__file__', None)
             ), "setup_path failed for %s. Does %s/__init__.py exist?" % (package, hash_overwrite)
     path = os.path.dirname(module.__file__)
+    path = os.path.relpath(path)
+
     return RelPath(path, hash_overwrite=hash_overwrite)
 
 

--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -48,6 +48,7 @@ import tarfile
 import tempfile
 from typing import Union, Any, List, Optional
 import subprocess
+import importlib
 
 from sisyphus.tools import sh, extract_paths
 import sisyphus.block
@@ -222,12 +223,9 @@ def setup_path(package: str) -> RelPath:
     assert package, ("setup_path is used to make all path relative to the current package directory, "
                      "it only works inside of directories and not if the config file is passed directly")
 
-    path = package.replace('.', '/')
-    hash_overwrite = None
-    if package.startswith(gs.RECIPE_PREFIX):
-        hash_overwrite = path
-        path = os.path.join(gs.RECIPE_PATH, path)
-
+    hash_overwrite = package.replace('.', '/')
+    module = importlib.import_module(package)
+    path = os.path.dirname(module.__file__)
     return RelPath(path, hash_overwrite=hash_overwrite)
 
 

--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -225,6 +225,8 @@ def setup_path(package: str) -> RelPath:
 
     hash_overwrite = package.replace('.', '/')
     module = importlib.import_module(package)
+    assert (getattr(module, '__file__', None)
+            ), "setup_path failed for %s. Does %s/__init__.py exist?" % (package, hash_overwrite)
     path = os.path.dirname(module.__file__)
     return RelPath(path, hash_overwrite=hash_overwrite)
 


### PR DESCRIPTION
These changes allows to store the recipes without the recipe prefix in arbitrary locations by settings IMPORT_PATHS in settings.py accordingly. e.g.: IMPORT_PATHS = ['config', 'recipe/'] will load everything inside of the recipe/ folder without the recipe prefix.