### PR TITLE
Added possibility to cache results of finished jobs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = F401, C901, F403, F405
+ignore = F401, C901, F403, F405, W503
 max-line-length = 120
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/sisyphus/__main__.py
+++ b/sisyphus/__main__.py
@@ -170,6 +170,15 @@ def main():
     else:
         logging.basicConfig(format='[%(asctime)s] %(levelname)s: %(message)s', level=args.log_level)
 
+    # Disable cache for worker
+    if args.func == worker:
+        gs.CACHE_FINISHED_RESULTS = False
+
+    # Load cache
+    if gs.CACHE_FINISHED_RESULTS:
+        from sisyphus.tools import finished_results_cache
+        finished_results_cache.read_from_file()
+
     # Changing settings via commandline is currently not supported
     # Needs to ensure all parameters are passed correctly to worker, ignored since nobody requested it so far
     # update_global_settings_from_file(args.settings_file)

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -291,6 +291,14 @@ JOB_ADD_STACKTRACE_WITH_DEPTH = 0
 # Is enabled if tk.run is called
 SKIP_IS_FINISHED_TIMEOUT = False
 
+# Caching
+#: If enabled the results of finished jobs are cached in an extra file to reduce the file system access
+CACHE_FINISHED_RESULTS = False
+#: Path used for CACHE_FINISHED_RESULTS
+CACHE_FINISHED_RESULTS_PATH = "finished_results_cache.pkl"
+#: Only cache results smaller than this in central file (in bytes)
+CACHE_FINISHED_RESULTS_MAX_SIZE = 1024
+
 # Warnings
 #: Warn if a config file is loaded without calling a function
 WARNING_NO_FUNCTION_CALLED = True

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -23,6 +23,7 @@ from typing import List, Iterator
 from sisyphus import block, tools
 from sisyphus.task import Task
 from sisyphus.job_path import Path, Variable
+from sisyphus.tools import finished_results_cache
 
 # Definition of constants
 import sisyphus.global_settings as gs
@@ -50,6 +51,7 @@ def get_args(f, args, kwargs):
 created_jobs = {}
 
 
+@finished_results_cache.caching(get_key=lambda path: ('job', path))
 def job_finished(path):
     """ Return true if given job is finished according to files in directory
     :param path: path to directory

--- a/tests/job_path_unittest.py
+++ b/tests/job_path_unittest.py
@@ -4,6 +4,7 @@ import pickle
 
 import sisyphus.toolkit as tk
 from sisyphus.job_path import Path, Variable
+from sisyphus.tools import finished_results_cache
 
 
 class MockJob(object):
@@ -100,6 +101,7 @@ class PathTest(unittest.TestCase):
                 pass
             self.assertEqual(path.available(), True)
 
+        finished_results_cache.reset()
         path = Path('lm.gz', mjob, available=path_available_false)
         self.assertEqual(path.available(), False)
         path = Path('lm.gz', mjob, available=path_available_true)


### PR DESCRIPTION
Creates a file to cache all finished jobs to one central file. Should speed up the startup time of systems with many finished jobs which use variables for reports etc.