### PR TITLE
User settings file

### DIFF
--- a/sisyphus/global_constants.py
+++ b/sisyphus/global_constants.py
@@ -25,6 +25,7 @@ CONFIG_PREFIX = "config"
 RECIPE_PREFIX = "recipe"
 
 # settings file
+GLOBAL_SETTINGS_FILE_USER = os.path.expanduser('~/.sisyphus_settings.py')
 GLOBAL_SETTINGS_FILE_DEFAULT = "settings.py"
 
 # File states

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -347,7 +347,6 @@ def update_global_settings_from_file(filename):
     :param str filename:
     :return: nothing
     """
-    # skip if settings file doesn't exist
     globals()['GLOBAL_SETTINGS_FILE'] = filename
 
     content = ''
@@ -355,6 +354,7 @@ def update_global_settings_from_file(filename):
         with open(filename, encoding='utf-8') as f:
             content = f.read()
     except IOError as e:
+        # skip if settings file doesn't exist
         if e.errno != 2:
             raise e
 
@@ -393,4 +393,5 @@ USE_UI = True
 ENGINE_NOT_SETUP_WARNING = True
 
 update_global_settings_from_env()
+update_global_settings_from_file(GLOBAL_SETTINGS_FILE_USER)
 update_global_settings_from_file(GLOBAL_SETTINGS_FILE_DEFAULT)

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -392,6 +392,6 @@ USE_UI = True
 # Set to False to disable Warning of unset engine
 ENGINE_NOT_SETUP_WARNING = True
 
-update_global_settings_from_env()
 update_global_settings_from_file(GLOBAL_SETTINGS_FILE_USER)
 update_global_settings_from_file(GLOBAL_SETTINGS_FILE_DEFAULT)
+update_global_settings_from_env()


### PR DESCRIPTION
Adding support for a user base settings file stored under `~/sisyphus_settings.py`
Just checking if you see any reason not to add it.