### PR TITLE
add worker check for Delayed

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -306,6 +306,8 @@ WARNING_NO_FUNCTION_CALLED = True
 #: Warn if an absolute path inside the current directory is created
 WARNING_ABSPATH = True
 
+# Prohibit resolving paths in graph construction
+DELAYED_CHECK_FOR_WORKER = False
 
 # Internal functions
 def update_global_settings_from_text(text, filename):


### PR DESCRIPTION
I thought it is a good idea to add a gs variable that prohibits resolving any "Delayed" object  while still being in the "graph" thread. I saw that this is the most common error when working with Sisyphus.