### PR TITLE
Removed code to log last file usage since it didn't prove useful in practice

### DIFF
--- a/sisyphus/global_constants.py
+++ b/sisyphus/global_constants.py
@@ -8,7 +8,6 @@ JOB_LOG_ENGINE = 'engine'
 JOB_SAVE = 'job.save'
 JOB_WORK_DIR = 'work'
 JOB_FINISHED_MARKER = 'finished'
-JOB_LAST_USER = 'last_user'
 JOB_FINISHED_ARCHIVE = 'finished.tar.gz'
 JOB_INFO = 'info'
 

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -130,8 +130,6 @@ def file_caching(path):
 
 
 # Experimental settings
-# Log when a job output was used the last time, currently not active maintained
-ENABLE_LAST_USAGE = False
 # Add tags attached to job to work path, currently not active maintained
 JOB_USE_TAGS_IN_PATH = False
 # Start kernel to connect remotely, currently not active maintained

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -253,15 +253,12 @@ class Job(metaclass=JobSingleton):
                 gs.JOB_WORK_DIR,
                 gs.JOB_OUTPUT,
                 gs.JOB_INPUT,
-                gs.JOB_LOG_ENGINE,
-                gs.JOB_LAST_USER]:
+                gs.JOB_LOG_ENGINE]:
             path = self._sis_path(dirname)
             try:
                 os.makedirs(path)
             except FileExistsError:
                 assert os.path.isdir(path)
-
-        os.chmod(self._sis_path(gs.JOB_LAST_USER), 0o775)
 
         for dirname in self._sis_output_dirs:
             path = str(dirname)

--- a/sisyphus/task.py
+++ b/sisyphus/task.py
@@ -128,29 +128,7 @@ class Task(object):
             except FileNotFoundError:
                 logging.warning('Input path does not exist: %s' % i.get_path())
 
-            if i.creator and gs.ENABLE_LAST_USAGE:
-                # mark that input was used
-                try:
-                    os.unlink(os.path.join(i.creator, gs.JOB_LAST_USER, os.getlogin()))
-                except OSError as e:
-                    if e.errno not in (2, 13):
-                        # 2: file not found
-                        # 13: permission denied
-                        raise e
-
-                try:
-                    user_path = os.path.join(i.creator, gs.JOB_LAST_USER, os.getlogin())
-                    os.symlink(os.path.abspath(job._sis_path()), user_path)
-                    os.chmod(user_path, 0o775)
-                except OSError as e:
-                    if e.errno not in (2, 13, 17):
-                        # 2: file not found
-                        # 13: permission denied
-                        # 17: file exists
-                        raise e
-
         tools.get_system_informations(sys.stdout)
-
         sys.stdout.flush()
 
         try:


### PR DESCRIPTION
This code was originally added to log when a job output was used the last time.
I would like to remove it since it's not used by anybody afaik, adds an unused directory to every job and I don't want to support this feature in the future.
Any objections?