### PR TITLE
workaround for pickle problem

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -104,7 +104,7 @@ class JobSingleton(type):
                 tags.update(p.tags)
 
         # check cache
-        if sis_id in created_jobs:
+        if sis_id in created_jobs and vars(created_jobs[sis_id]):
             job = created_jobs[sis_id]
         else:
             # create new object


### PR DESCRIPTION
I got the strange error:
```
AttributeError: 'BeamSearchJob' object has no attribute '_sis_alias_prefixes'
```
When running a job called `OldToNewTranscriptions`, which (indirectly only) depends on some output of `BeamSearchJob`.

Full error: https://gist.github.com/albertz/8429f7ad06bf32832b7c6ff227598982

Job code: https://gist.github.com/albertz/8429f7ad06bf32832b7c6ff227598982

The error occurred during unpickling. While debugging, I noticed that it would go into the `if sis_id in created_jobs` code branch and it had an empty object (`_sis_init` was never called). So extending the check to `if sis_id in created_jobs and vars(created_jobs[sis_id])` fixed the problem for me.

I have not fully unterstand the real issue here and I'm not sure this is the best fix. But anyway.
