### PR TITLE
Bugfix for get_job_from_path

### DIFF
--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -649,8 +649,8 @@ class SISGraph(object):
             if len(t.required_full_list) == 1:
                 current[t.name] = t.required_full_list[0]
             else:
-                for pos, path in enumerate(t.required_full_list):
-                    current["%s_%02i" % (t.name, pos)] = path
+                for pos, required_path in enumerate(t.required_full_list):
+                    current["%s_%02i" % (t.name, pos)] = required_path
 
         for step in path:
             if isinstance(current, dict):


### PR DESCRIPTION
The path argument in get_job_from_path is overwritten by the variable in the inner loop.
This causes that get_job_from_path always returns None.

Noticed this when trying to migrate a large graph.