### PR TITLE
Call check_engine_limits on initial submit

### DIFF
--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -102,6 +102,9 @@ class EngineBase:
         else:
             # never submitted so far, use default values
             rqmt = default_rqmt
+        rqmt = gs.check_engine_limits(rqmt, task)
+        if 'mem' in rqmt:
+            rqmt['mem'] = tools.str_to_GB(rqmt['mem'])
         return rqmt
 
     def job_state(self, job):

--- a/sisyphus/task.py
+++ b/sisyphus/task.py
@@ -418,7 +418,6 @@ class Task(object):
         if 'time' in rresources:
             rresources['time'] = tools.str_to_hours(rresources['time'])
         new_rqmt = self._update_rqmt(initial_rqmt=initial_rqmt, last_usage=last_usage)
-        new_rqmt = gs.check_engine_limits(new_rqmt, self)
         return new_rqmt
 
     def get_process_logging_path(self, task_id):


### PR DESCRIPTION
This moves the call of `gs.check_engine_limits` from `Task.update_rqmt` to `EngineBase.get_rqmt`. This way the requirements are already checked on the initial submit and not only after the requirements are updated.

This helps to avoid issues if the initial job requirements are already too high for the current engine.

Also based on the documentation in global_settings.py, I expected that the method would be called also on the first submission of tasks.
