### PR TITLE
SISGraph for_all_nodes more efficient single-threaded

### DIFF
--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -489,69 +489,77 @@ class SISGraph(object):
                     if path.creator:
                         nodes.append(path.creator)
 
+        if gs.GRAPH_WORKER == 1:
+            visited_set = set()
+            visited_list = []
+            queue = list(reversed(nodes))
+            while queue:
+                job = queue.pop(-1)
+                if id(job) in visited_set:
+                    continue
+                visited_set.add(id(job))
+                job._sis_runnable()
+
+                if bottom_up:
+                    # execute in reverse order at the end
+                    visited_list.append(job)
+                else:
+                    res = f(job)
+                    # Stop if function has a not None but false return value
+                    if res is not None and not res:
+                        continue
+
+                for path in job._sis_inputs:
+                    if path.creator:
+                        if id(path.creator) not in visited_set:
+                            queue.append(path.creator)
+
+            if bottom_up:
+                for job in reversed(visited_list):
+                    f(job)
+
+            return visited_set
+
         visited = {}
         finished = 0
 
-        if gs.GRAPH_WORKER == 1:
-            # Run in main thread if only one graph worker is given anyway
-            def runner(job):
-                """
-                :param Job job:
-                """
-                # make sure all inputs are updated
-                job._sis_runnable()
+        pool_lock = threading.Lock()
+        finished_lock = threading.Lock()
+        pool = self.pool
 
-                if bottom_up:
+        # recursive function to run through tree
+        def runner(job):
+            """
+            :param Job job:
+            """
+            sis_id = job._sis_id()
+            with pool_lock:
+                if sis_id not in visited:
+                    visited[sis_id] = pool.apply_async(
+                        tools.default_handle_exception_interrupt_main_thread(runner_helper), (job,))
+
+        def runner_helper(job):
+            """
+            :param Job job:
+            """
+            # make sure all inputs are updated
+            job._sis_runnable()
+            nonlocal finished
+
+            if bottom_up:
+                for path in job._sis_inputs:
+                    if path.creator:
+                        runner(path.creator)
+                f(job)
+            else:
+                res = f(job)
+                # Stop if function has a not None but false return value
+                if res is None or res:
                     for path in job._sis_inputs:
                         if path.creator:
                             runner(path.creator)
-                    f(job)
-                else:
-                    res = f(job)
-                    # Stop if function has a not None but false return value
-                    if res is None or res:
-                        for path in job._sis_inputs:
-                            if path.creator:
-                                runner(path.creator)
-
-        else:
-            pool_lock = threading.Lock()
-            finished_lock = threading.Lock()
-            pool = self.pool
-
-            # recursive function to run through tree
-            def runner(job):
-                """
-                :param Job job:
-                """
-                sis_id = job._sis_id()
-                with pool_lock:
-                    if sis_id not in visited:
-                        visited[sis_id] = pool.apply_async(
-                            tools.default_handle_exception_interrupt_main_thread(runner_helper), (job,))
-
-            def runner_helper(job):
-                """
-                :param Job job:
-                """
-                # make sure all inputs are updated
-                job._sis_runnable()
-                nonlocal finished
-
-                if bottom_up:
-                    for path in job._sis_inputs:
-                        if path.creator:
-                            runner(path.creator)
-                    f(job)
-                else:
-                    res = f(job)
-                    # Stop if function has a not None but false return value
-                    if res is None or res:
-                        for path in job._sis_inputs:
-                            if path.creator:
-                                runner(path.creator)
-                with finished_lock:
-                    finished += 1
+            with finished_lock:
+                finished += 1
 
         for node in nodes:
             runner(node)


### PR DESCRIPTION
This gives me some huge speedup, of a big GMM pipeline, from hours of runtime (I let it run for about 30 mins and then stopped, so I don't actually know) down to 20 secs runtime.

This is with `GRAPH_WORKER = 1`.

The main problem is that this did not keep track of visited nodes for this case.

But also, when comparing this implementation now to the case of `GRAPH_WORKER > 1` (e.g. `GRAPH_WORKER = 16`), it's more than twice as fast. And this is expected: I don't see any reason why a multi-threaded implementation can make it any faster:
* Any computation in Python is actually single threaded due to the GIL.
* There is a lot of overhead involved with the multithreading logic.
* If the FS is the bottleneck, there is also no point in having it multithreaded.

So, I would even suggest to go further and completely remove the multithreaded implementation.
