### PR TITLE
XML ElementTree fix for python3.9+

### DIFF
--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -332,7 +332,7 @@ class SonOfGridEngine(EngineBase):
             return self.queue_state()
 
         task_infos = defaultdict(list)
-        for job in etree.getiterator('job_list'):
+        for job in etree.iter('job_list'):
             job_info = {}
             for attr in job:
                 text = attr.text


### PR DESCRIPTION
The `getiterator()` function in `xml.etree.ElementTree` was deprecated and got removed in python3.9. This replaces the function by `iter()`.