### PR TITLE
change keep value remove msg

### DIFF
--- a/sisyphus/cleaner.py
+++ b/sisyphus/cleaner.py
@@ -292,7 +292,7 @@ def cleanup_keep_value(min_keep_value, load_from: str = '', mode: str = 'remove'
         job_dirs = extract_keep_values_from_graph()
 
     to_remove = find_too_low_keep_value(job_dirs, min_keep_value)
-    remove_directories(to_remove, 'Keep value is too low', move_postfix='.cleanup', mode=mode, force=False)
+    remove_directories(to_remove, 'Remove jobs with lower keep value than min', move_postfix='.cleanup', mode=mode, force=False)
 
 
 def cleanup_unused(load_from: str = '', job_dirs=None):


### PR DESCRIPTION
Small PR to change the msg. that shows when using the clenup keep value function.
I found "Keep Value too low" confusing, since to me it suggested that the value I set was too low instead of removing jobs with too low value. 
The new msg. is just a suggestion from me, I am fine with other suggestions if you dont like this one.