### PR TITLE
config from recipe, maybe remove import path prefix

### DIFF
--- a/sisyphus/loader.py
+++ b/sisyphus/loader.py
@@ -43,6 +43,11 @@ class ConfigManager:
 
         toolkit.set_root_block(filename)
 
+        # maybe remove import path prefix such as "recipe/"
+        for load_path in gs.IMPORT_PATHS:
+            if load_path.endswith('/') and filename.startswith(load_path):
+                filename = filename[len(load_path):]
+                break
         filename = filename.replace(os.path.sep, '.')  # allows to use tab completion for file selection
         assert all(part.isidentifier() for part in filename.split('.')), "Config name is invalid: %s" % filename
         module_name, function_name = filename.rsplit('.', 1)


### PR DESCRIPTION
Extension to #91, #100.

E.g. when you now do:
```
sis m recipe/i6_experiments/users/zeyer/experiments/exp2022_07_21_transducer/pipeline_swb_2020.py
```
When having `"recipe/"` in my `gs.IMPORT_PATHS`, I want that it loads the module `i6_experiments.users.zeyer.experiments.exp2022_07_21_transducer.pipeline_swb_2020`, not with the `recipe.` prefix.

To be fair, it's a bit ambiguous when you have both `"recipe/"` and `"recipe"`. Then both work but then it depends on how the remaining recipes are implemented, and whether their imports are using the `recipe.` prefix or not. But I think most don't use it, e.g. [i6_core](https://github.com/rwth-i6/i6_core/blob/main/returnn/training.py), which is maybe most relevant.

As the main user so far of this feature (#91), I think this gives some priority to my own preference here, i.e. like I implemented it here in the PR. :)
