### PR TITLE
absolute path warning only without hash_overwrite

### DIFF
--- a/sisyphus/job_path.py
+++ b/sisyphus/job_path.py
@@ -57,7 +57,7 @@ class AbstractPath(DelayedBase):
                                         Gets path as input and must be pickleable
         """
 
-        if gs.WARNING_ABSPATH and path.startswith(gs.BASE_DIR):
+        if gs.WARNING_ABSPATH and path.startswith(gs.BASE_DIR) and not hash_overwrite:
             logging.warning('Creating absolute path inside current work directory: %s '
                             '(disable with WARNING_ABSPATH=False)' % path)
         assert isinstance(path, str)


### PR DESCRIPTION
When `hash_overwrite` is given, it should not matter.

I esp have the cases that I have some resources inside my base dir which I need to reference but I provide a `hash_overwrite` so that no hash is dependent on the absolute path.

I don't just want to disable the warning because the warning is still useful.