### PR TITLE
multi_node_slots option for rqmt

### DIFF
--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -133,8 +133,8 @@ class AWSBatchEngine(EngineBase):
         # TODO time
         # time = rqmt.get('mem', 1)
 
-        if rqmt.get('parallel_tasks', None):
-            raise NotImplementedError('Parallel tasks are not implemented for AWS Batch')
+        if rqmt.get('multi_node_slots', None):
+            raise NotImplementedError('Multi-node slots are not implemented for AWS Batch')
 
         for task_id in task_ids:
             call_with_id = call[:] + [str(task_id)]

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -132,6 +132,10 @@ class AWSBatchEngine(EngineBase):
         mem = int(rqmt.get('mem', 1) * 1024)  # AWS uses MiB
         # TODO time
         # time = rqmt.get('mem', 1)
+
+        if rqmt.get('parallel_tasks', None):
+            raise NotImplementedError('Parallel tasks are not implemented for AWS Batch')
+
         for task_id in task_ids:
             call_with_id = call[:] + [str(task_id)]
 

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -114,6 +114,10 @@ class LoadSharingFacilityEngine(EngineBase):
         task_time = try_to_multiply(rqmt['time'], 60)  # convert to minutes if possible
 
         out.append('-W %s' % task_time)
+
+        if rqmt.get('parallel_tasks', None):
+            raise NotImplementedError('Parallel tasks are not implemented for LSF')
+
         bsub_args = rqmt.get('bsub_args', [])
         if isinstance(bsub_args, str):
             bsub_args = bsub_args.split()

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -115,8 +115,8 @@ class LoadSharingFacilityEngine(EngineBase):
 
         out.append('-W %s' % task_time)
 
-        if rqmt.get('parallel_tasks', None):
-            raise NotImplementedError('Parallel tasks are not implemented for LSF')
+        if rqmt.get('multi_node_slots', None):
+            raise NotImplementedError('Multi-node slots are not implemented for LSF')
 
         bsub_args = rqmt.get('bsub_args', [])
         if isinstance(bsub_args, str):

--- a/sisyphus/localengine.py
+++ b/sisyphus/localengine.py
@@ -217,6 +217,8 @@ class LocalEngine(threading.Thread, EngineBase):
                     logging.warning(' Running task: %s %i PID: %s' % (task_name, task_id, value[0].pid))
 
     def submit_call(self, call, logpath, rqmt, name, task_name, task_ids):
+        if rqmt.get('parallel_tasks', None):
+            raise NotImplementedError('Parallel tasks are not implemented for local engine')
         # run one thread for each task id
         for task_id in task_ids:
             call_with_id = call[:] + [str(task_id)]

--- a/sisyphus/localengine.py
+++ b/sisyphus/localengine.py
@@ -217,8 +217,8 @@ class LocalEngine(threading.Thread, EngineBase):
                     logging.warning(' Running task: %s %i PID: %s' % (task_name, task_id, value[0].pid))
 
     def submit_call(self, call, logpath, rqmt, name, task_name, task_ids):
-        if rqmt.get('parallel_tasks', None):
-            raise NotImplementedError('Parallel tasks are not implemented for local engine')
+        if rqmt.get('multi_node_slots', None):
+            raise NotImplementedError('Multi-node slots are not implemented for local engine')
         # run one thread for each task id
         for task_id in task_ids:
             call_with_id = call[:] + [str(task_id)]

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -148,8 +148,8 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         out.append('--time=%s' % task_time)
         out.append('--export=all')
 
-        if rqmt.get('parallel_tasks', None):
-            out.append('--ntasks=%s' % rqmt['parallel_tasks'])
+        if rqmt.get('multi_node_slots', None):
+            out.append('--ntasks=%s' % rqmt['multi_node_slots'])
 
         sbatch_args = rqmt.get('sbatch_args', [])
         if isinstance(sbatch_args, str):

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -148,6 +148,9 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         out.append('--time=%s' % task_time)
         out.append('--export=all')
 
+        if rqmt.get('parallel_tasks', None):
+            out.append('--ntasks=%s' % rqmt['parallel_tasks'])
+
         sbatch_args = rqmt.get('sbatch_args', [])
         if isinstance(sbatch_args, str):
             sbatch_args = sbatch_args.split()

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -61,7 +61,9 @@ class SonOfGridEngine(EngineBase):
         :param list[str] ignore_jobs: list of job ids that will be ignored during status updates.
                                       Useful if a job is stuck inside of SGE and can not be deleted.
                                       Job should be listed as "job_number.task_id" e.g.: ['123.1', '123.2', '125.1']
-        :param str pe_name: used to select parallel environment (PE), when parallel_tasks is set in rqmt
+        :param str pe_name: used to select parallel environment (PE), when parallel_tasks is set in rqmt,
+                            as `-pe <pe_name> <parallel_tasks>`.
+                            The default "mpi" is somewhat arbitrarily choosen as we have it in our environment.
         """
         self._task_info_cache_last_update = 0
         self.gateway = gateway

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -61,9 +61,9 @@ class SonOfGridEngine(EngineBase):
         :param list[str] ignore_jobs: list of job ids that will be ignored during status updates.
                                       Useful if a job is stuck inside of SGE and can not be deleted.
                                       Job should be listed as "job_number.task_id" e.g.: ['123.1', '123.2', '125.1']
-        :param str pe_name: used to select parallel environment (PE), when parallel_tasks is set in rqmt,
-                            as `-pe <pe_name> <parallel_tasks>`.
-                            The default "mpi" is somewhat arbitrarily choosen as we have it in our environment.
+        :param str pe_name: used to select parallel environment (PE), when multi_node_slots is set in rqmt,
+                            as `-pe <pe_name> <multi_node_slots>`.
+                            The default "mpi" is somewhat arbitrarily chosen as we have it in our environment.
         """
         self._task_info_cache_last_update = 0
         self.gateway = gateway
@@ -176,8 +176,8 @@ class SonOfGridEngine(EngineBase):
         out.append('-l')
         out.append('h_rt=%s' % task_time)
 
-        if rqmt.get('parallel_tasks', None):
-            out.extend(['-pe', self.pe_name, str(rqmt['parallel_tasks'])])
+        if rqmt.get('multi_node_slots', None):
+            out.extend(['-pe', self.pe_name, str(rqmt['multi_node_slots'])])
 
         qsub_args = rqmt.get('qsub_args', [])
         if isinstance(qsub_args, str):

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -52,7 +52,7 @@ def try_to_multiply(y, x, backup_value=None):
 
 class SonOfGridEngine(EngineBase):
 
-    def __init__(self, default_rqmt, gateway=None, auto_clean_eqw=True, ignore_jobs=None):
+    def __init__(self, default_rqmt, gateway=None, auto_clean_eqw=True, ignore_jobs=None, pe_name="mpi"):
         """
 
         :param dict default_rqmt: dictionary with the default rqmts
@@ -61,6 +61,7 @@ class SonOfGridEngine(EngineBase):
         :param list[str] ignore_jobs: list of job ids that will be ignored during status updates.
                                       Useful if a job is stuck inside of SGE and can not be deleted.
                                       Job should be listed as "job_number.task_id" e.g.: ['123.1', '123.2', '125.1']
+        :param str pe_name: used for parallel environment (PE), when parallel_tasks is set to rqmt
         """
         self._task_info_cache_last_update = 0
         self.gateway = gateway
@@ -69,6 +70,7 @@ class SonOfGridEngine(EngineBase):
         if ignore_jobs is None:
             ignore_jobs = []
         self.ignore_jobs = ignore_jobs
+        self.pe_name = pe_name
 
     def system_call(self, command, send_to_stdin=None):
         """
@@ -171,6 +173,10 @@ class SonOfGridEngine(EngineBase):
 
         out.append('-l')
         out.append('h_rt=%s' % task_time)
+
+        if rqmt.get('parallel_tasks', None):
+            out.extend(['-pe', self.pe_name, str(rqmt['parallel_tasks'])])
+
         qsub_args = rqmt.get('qsub_args', [])
         if isinstance(qsub_args, str):
             qsub_args = qsub_args.split()

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -61,7 +61,7 @@ class SonOfGridEngine(EngineBase):
         :param list[str] ignore_jobs: list of job ids that will be ignored during status updates.
                                       Useful if a job is stuck inside of SGE and can not be deleted.
                                       Job should be listed as "job_number.task_id" e.g.: ['123.1', '123.2', '125.1']
-        :param str pe_name: used for parallel environment (PE), when parallel_tasks is set to rqmt
+        :param str pe_name: used to select parallel environment (PE), when parallel_tasks is set in rqmt
         """
         self._task_info_cache_last_update = 0
         self.gateway = gateway

--- a/sisyphus/task.py
+++ b/sisyphus/task.py
@@ -26,6 +26,9 @@ class Task(object):
                 "gpu": number of gpus
                 "mem": amount of memory, in GB
                 "time": amount of time, in hours
+                "multi_node_slots": amount of slots, distributed potentially over multiple nodes.
+                                    E.g. maps to `--ntasks <multi_node_slots>` parameter for Slurm,
+                                    and to `-pe <pe_name> <multi_node_slots>` for SGE (SGE parallel environment (PE)).
         :param typing.Sequence[typing.Union[typing.List[object],object]] args: job arguments
         :param bool mini_task: will be run on engine for short jobs if True
         :param (dict[str],dict[str])->dict[str] update_rqmt: function to update job requirements for interrupted jobs


### PR DESCRIPTION
Maps to parallel environment (PE) for SGE, and to ntasks for Slurm, and other engines will throw an exception.

Needed for https://github.com/rwth-i6/i6_core/pull/333.