### PR TITLE
Change default memory_allocation_type in SLURM Engine 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The memory_allocation_type in the slurm engine now default to per_node instead of per_cpu for consistency with other engines
+
 ### Added
 - Support for async workflow definitions. If await tk.async_run(obj) is called sisyphus will wait until all Path objects inside of obj are available
 - Path has now is_set method

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -45,7 +45,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         PER_NODE = "per_node"
 
     def __init__(self, default_rqmt, gateway=None, has_memory_resource=True, auto_clean_eqw=True,
-                 ignore_jobs=[], memory_allocation_type=MemoryAllocationType.PER_CPU):
+                 ignore_jobs=[], memory_allocation_type=MemoryAllocationType.PER_NODE):
         """
 
         :param dict default_rqmt: dictionary with the default rqmts


### PR DESCRIPTION
The memory allocation type in the SLURM engine currently defaults to per_cpu.
I.e. if a task requests `{'cpu': 2, 'mem': 16}` a node with 32GB of memory is requested for the task.

For all other engines (e.g. the sge engine or the local engine) the `mem` rqmt always corresponds to the total memory on a node. I'd have expected that per default the slurm engine behaves identically.

For consistency between different engines, I propose to switch the default from `per_cpu` to `per_node`. This may be a breaking change for some setups, though I'm not aware of any sisyphus users exclusively using slurm.
On the other hand, multiple heavy sisyphus users are going to switch from the sge to slurm soon and are probably not aware of this difference in behaviour and thus will request more memory than intended for their jobs.
