### PR TITLE
Fixes CI by fixing the ubuntu version to 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The CI runner currently fails with 
```
Error: Version 3.6 with arch x64 not found
```

ubuntu-latest now defaults to ubuntu 22.04 for which python 3.6 is not available anymore.
