### PR TITLE
New install strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Sisyphus requires a Python >=3.6 installation with the following additional libr
 
 ## Setup
 
-* Add `sis` to the `PATH` env, or symlink it, or call it directly.
+* After the requirements are installed, install `sis`. This can be done with
+  ```
+  pip3 install git+https://github.com/rwth-i6/sisyphus.git
+  ```
 * The current directory (`pwd`), when you run `sis`, should have a file `settings.py` (see `example` dir).
 * Create a directory `work` in the current dir.
   All data created while running the jobs will be stored there.
@@ -49,9 +52,9 @@ Sisyphus requires a Python >=3.6 installation with the following additional libr
 Can be found here: [sisyphus-workflow-manager.readthedocs.io](https://sisyphus-workflow-manager.readthedocs.io/).
 
 
-# Example 
+# Example
 
-A short toy workflow example is given in the example directory. 
+A short toy workflow example is given in the example directory.
 
 To run sisyphus on the example workflow change into the `/example` directory and run `../sis manager`
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 
-
 setup(
     name='sisyphus',
     version='1.0.0',
@@ -10,5 +9,8 @@ setup(
     author="Jan-Thorsten Peter",
     author_email="jtpeter@apptek.com",
     url="https://github.com/rwth-i6/sisyphus",
-    install_requires=['psutil', 'flask']
+    install_requires=['psutil', 'flask'],
+    entry_points = {
+        "console_scripts": ["sisyphus=sisyphus.__main__:main","sis=sisyphus.__main__:main"]
+    }
 )


### PR DESCRIPTION
I really love sisyphus, and I am currently using it in my thesis. However, having to clone the repository and adding `sis` to `PATH` always struck me as kind of cumbersome. This means, for example, that sisyphus won't install itself neatly in any virtualenv. Is there a specific reason for this?

Alternatively adding
```python
entry_points = {
    "console_scripts": ["sisyphus=sisyphus.__main__:main","sis=sisyphus.__main__:main"]
}
```
as argument to the setup.py gives the user the ability to install sisyphus directly from VCS with pip in any venv while still giving them access to the `sis` and `sisyphus` shell commands. At least while the venv is activated. This PR implements these quick changes.

Incidentally, this resolves #45 as well, I think. 