### PR TITLE
Visualize job shortcut

### DIFF
--- a/sisyphus/block.py
+++ b/sisyphus/block.py
@@ -110,9 +110,15 @@ def set_root_block(name):
     :param str name:
     """
     global active_blocks
-    current_block = Block(name)
-    active_blocks = {current_block}
-    all_root_blocks.append(current_block)
+    # Linear search is fairly inefficient, but since there should not be many root blocks it shouldn't be a problem
+    for block in all_root_blocks:
+        if block.name == name:
+            active_blocks = {block}
+            break
+    else:
+        current_block = Block(name)
+        active_blocks = {current_block}
+        all_root_blocks.append(current_block)
 
 
 def sub_block(name):

--- a/sisyphus/helper.py
+++ b/sisyphus/helper.py
@@ -13,7 +13,10 @@ def console(args):
                }
 
     if args.load:
-        jobs = [sisyphus.toolkit.load_job(i) for i in args.load]
+        jobs = []
+        for job in args.load:
+            sisyphus.toolkit.set_root_block(job)
+            jobs.append(sisyphus.toolkit.load_job(job))
         user_ns['jobs'] = jobs
         for i, job in enumerate(jobs):
             print("jobs[%i]: %s" % (i, job))

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -333,6 +333,12 @@ class Job(metaclass=JobSingleton):
         self._sis_cleaned_or_not_cleanable = False
         for i in self._sis_inputs:
             i.add_user(self)
+
+        if block.active_blocks:
+            for b in block.active_blocks:
+                b.add_job(self)
+                self._sis_add_block(b)
+
         logging.debug('Set state %s' % state['_sis_id_cache'])
 
     def __getnewargs__(self):

--- a/sisyphus/job_path.py
+++ b/sisyphus/job_path.py
@@ -241,7 +241,8 @@ class AbstractPath(DelayedBase):
 
     def __setstate__(self, state):
         assert 'users' not in state
-        self.__dict__.update(state)
+        for k, v in state.items():
+            setattr(self, k, v)
         if not hasattr(self, 'users'):
             self.users = set()
 

--- a/sisyphus/shortcuts.py
+++ b/sisyphus/shortcuts.py
@@ -89,6 +89,15 @@ def add_subparsers(parsers):
                                                    help='All config files that will be loaded')
     parser_remove_job_and_descendants.set_defaults(func=remove_job_and_descendants)
 
+    parser_show_jobs_in_webserver = sc_subparsers.add_parser(
+        'show_jobs_in_webserver',
+        help="Start webserver which shows all given jobs")
+    parser_show_jobs_in_webserver.add_argument("--port", required=True,
+                                               help="Port for webserver to listen on")
+    parser_show_jobs_in_webserver.add_argument("--job", default=[], action='append',
+                                               help="path to job directory, can be given multiple times")
+    parser_show_jobs_in_webserver.set_defaults(func=show_job_in_webserver)
+
 
 def clean_unused(args):
     if args.load_used_path:
@@ -176,6 +185,14 @@ def remove_job_and_descendants(args):
     find = ' + '.join(
         ['tk.find_path(%s)' % repr(i) for i in args.path] + ['tk.find_job(%s)' % repr(i) for i in args.job])
     call = ['console', '--script', '-c', 'tk.remove_job_and_descendants(%s)' % find] + args.argv
+    call_sis(call)
+
+
+def show_job_in_webserver(args):
+    call = ['console', '--script']
+    for job in args.job:
+        call += ['--load', job]
+    call += ['-c', f'tk.show_jobs_in_webserver({args.port}, jobs)']
     call_sis(call)
 
 

--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -518,6 +518,22 @@ def job_info(job: Job):
     print("Work dir: %s" % job._sis_path(gs.WORK_DIR))
 
 
+def show_jobs_in_webserver(port: int, jobs: List[Job]):
+    """ Start web server on given port which displays given loaded jobs """
+    from sisyphus import http_server
+
+    web_graph = graph.SISGraph()
+    for job in jobs:
+        if job._sis_outputs:
+            output = next(iter(job._sis_outputs.values()))
+            web_graph.add_target(graph.OutputPath(str(job), output))
+        else:
+            print(f"Skipping {job} since this job has no output")
+    engine = cached_engine()
+    engine.start_engine()
+    http_server.start(sis_graph=web_graph, sis_engine=engine, port=port, thread=False)
+
+
 def print_graph(targets=None, required_inputs=None):
     visited = {}
     # create dictionary with available paths


### PR DESCRIPTION
Added a shortcut to load one or more jobs and display them with dependency using the web interface.

The graph interfaced used blocks group all jobs from a config together. This doesn't happen for loaded jobs, so I'm setting a new root block in sisyphus/helper.py line 18.
While working on that I realized that setting the root block was also broken for async workflows and fixed that as well.

Overall I'm not really happy with the whole block concept. Storing the current block in a global place feels ugly and is really error prone especially for async workflows... Anyway, here it should now be working again. 