### PR TITLE
Logging more data into "info"

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -299,6 +299,9 @@ class Job(metaclass=JobSingleton):
                     f.write('PARAMETER: %s: %s\n' % (key, value))
                 except UnicodeEncodeError as e:
                     f.write('PARAMETER: %s: <UnicodeEncodeError: %s>\n' % (key, e))
+            if self._sis_stacktrace:
+                f.write("STACKTRACE:\n")
+                f.writelines(traceback.format_list(self._sis_stacktrace[0]))
         self._sis_setup_since_restart = True
 
     def __getstate__(self):

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -302,9 +302,9 @@ class Job(metaclass=JobSingleton):
             if self._sis_aliases:
                 for alias in self._sis_aliases:
                     f.write('ALIAS: %s\n' % alias)
-            if self._sis_stacktrace:
+            for stacktrace in self._sis_stacktrace:
                 f.write('STACKTRACE:\n')
-                f.writelines(traceback.format_list(self._sis_stacktrace[0]))
+                f.writelines(traceback.format_list(stacktrace))
         self._sis_setup_since_restart = True
 
     def __getstate__(self):

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -299,8 +299,11 @@ class Job(metaclass=JobSingleton):
                     f.write('PARAMETER: %s: %s\n' % (key, value))
                 except UnicodeEncodeError as e:
                     f.write('PARAMETER: %s: <UnicodeEncodeError: %s>\n' % (key, e))
+            if self._sis_aliases:
+                for alias in self._sis_aliases:
+                    f.write('ALIAS: %s\n' % alias)
             if self._sis_stacktrace:
-                f.write("STACKTRACE:\n")
+                f.write('STACKTRACE:\n')
                 f.writelines(traceback.format_list(self._sis_stacktrace[0]))
         self._sis_setup_since_restart = True
 


### PR DESCRIPTION
Stacktrace and aliases are to be printed into the job info file.

These changes were tested on:
1. Multiple values of JOB_ADD_STACKTRACE_WITH_DEPTH.
2. Single config and single aliases for a single job.
3. Single config and multiple aliases for a single job.
4. Multiple configs and multiple aliases for a single job.