### PR TITLE
Update for Job used as argument warning

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -194,8 +194,8 @@ class Job(metaclass=JobSingleton):
         for key, arg in parsed_args.items():
             if isinstance(arg, Job):
                 logging.warning(
-                    "A Job instance was used as argument \"%s\" in \"%s\", this might result in undesired behavior" %
-                    (key, self.__class__))
+                    "The Job %s was used as argument \"%s\" in \"%s\", this might result in undesired behavior" %
+                    (str(arg)[3:], key, self.__class__))
 
         self._sis_aliases = None
         self._sis_alias_prefixes = set()


### PR DESCRIPTION
This PR suggests an update to the warning when using a Job as input:

The old warning e.g. would look like this, where in my opinion its not clear which job was used as an input, to pinpoint the code where this happend:
```
A Job instance was used as argument "corpus" in "<class i6_experiments.users.hilmes.tools.tts.speaker_embeddings.RemoveSpeakerTagsJob'>", this might result in undesired behavior
```

The new code would produce:
```
The Job <alias/Test/pfad/bis/ins/nichts... work/i6_experiments/users/hilmes/tools/tts/speaker_embeddings/RemoveSpeakerTagsJob.pXEVpRnGSiok> was used as argument "corpus
" in "<class 'i6_experiments.users.hilmes.tools.tts.speaker_embeddings.RemoveSpeakerTagsJob'>", this might result in undesired behavior
```
