### PR TITLE
Close ThreadPools on exit

### DIFF
--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -6,6 +6,7 @@ from sisyphus.block import Block
 import sisyphus.tools as tools
 import sisyphus.hash
 
+import atexit
 from inspect import isclass
 import logging
 import collections
@@ -229,6 +230,7 @@ class SISGraph(object):
     def pool(self):
         if self._pool is None:
             self._pool = ThreadPool(gs.GRAPH_WORKER)
+            atexit.register(self._pool.close)
         return self._pool
 
     @property

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import atexit
 import logging
 import os
 import sys
@@ -211,6 +212,7 @@ class Manager(threading.Thread):
 
         # Disable parallel mode for now, seems buggy
         self.thread_pool = ThreadPool(gs.MANAGER_SUBMIT_WORKER)
+        atexit.register(self.thread_pool.close)
         self.job_cleaner = None
 
         # Cached states of jobs


### PR DESCRIPTION
This causes errors when the manager stops in some cases. Error message:
```
Exception ignored in: <function Pool.__del__ at 0x7fe03c51e820>
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/multiprocessing/pool.py", line 268, in __del__
  File "/usr/local/lib/python3.8/multiprocessing/queues.py", line 362, in put
AttributeError: 'NoneType' object has no attribute 'dumps'
```