### PR TITLE
respect "required" in OutputReport

### DIFF
--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -144,7 +144,7 @@ class OutputCall(OutputTarget):
 
 class OutputReport(OutputTarget):
     def __init__(self, output_path, report_values, report_template=None, required=None, update_frequency=300):
-        super().__init__(output_path, report_values)
+        super().__init__(output_path, required if required is not None else report_values)
         self._report_template = report_template
         self._report_values = report_values
         self._output_path = output_path


### PR DESCRIPTION
The parameter `required` of `OutputReport` was previously unused. 
The same parameter is used by `OutputCall` to explicitly list all inputs that need to be finished in order for the Call to run - e.g. in case the automatic detection fails. I assume the same functionality was planned for `OutputReport` as well.

Point of contention: the function `update_values(self, report_values)` currently does not have such functionality. Should I add it? 