### PR TITLE
Add option to not print Jobs in HOLD state

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -204,6 +204,8 @@ PRINT_ERROR = True
 PRINT_ERROR_TASKS = 1
 #: Print that many last lines of error state log file
 PRINT_ERROR_LINES = 40
+#: Print message for held jobs
+PRINT_HOLD = True
 
 #: Which command should be called to start sisyphus, can be used to replace the python binary
 SIS_COMMAND = [sys.executable, sys.argv[0]]

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -285,9 +285,10 @@ class Manager(threading.Thread):
         elif state in [gs.STATE_INTERRUPTED_RESUMABLE, gs.STATE_UNKNOWN]:
             logging.warning(info_string)
         elif state in [gs.STATE_QUEUE,
-                       gs.STATE_HOLD,
                        gs.STATE_RUNNING,
                        gs.STATE_RUNNABLE]:
+            logging.info(info_string)
+        elif state == gs.STATE_HOLD and gs.PRINT_HOLD:
             logging.info(info_string)
         elif verbose:
             logging.info(info_string)


### PR DESCRIPTION
Sometimes you know that a NN training will not be good, so you cancel it after an early epoch.
One could then remove it from the graph, but 
* this is rather complicated if one uses nested for loops to setup all the jobs
* makes it intransparent why this experiment was removed (i.e. we might still want to see the bad scores of the early epochs)

The next best option is to manually mark the training as HOLD (or ERROR), but then we will still be reminded in the manager about this job, that we do not want any more. (can be really a lot of lines sometimes)

So here I propose a setting `PRINT_HOLD` (default `True` to preserve the old behavior). The manager will skip printing lines for held Jobs if this is set to False. The number of held jobs will still be printed in the overview to remind us of these jobs.