### PR TITLE
Force update when all calculations are done

### DIFF
--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -486,7 +486,7 @@ class Manager(threading.Thread):
             elif answer.lower() in ('u'):
                 self.link_outputs = True
                 create_aliases(self.sis_graph.jobs())
-                self.check_output(write_output=self.link_outputs, update_all_outputs=True)
+                self.check_output(write_output=self.link_outputs, update_all_outputs=True, force_update=True)
             return False
 
         self.print_state_overview()


### PR DESCRIPTION
For consistency I propose to force the update in the case the user answers the question
```
All calculations are done, print verbose overview (v), update outputs and alias (u), cancel (c)? 
```
with `u` (update).

The flag `force_update` is already set in case of the question 
```
Print verbose overview (v), update aliases and outputs (u), start manager (y), or exit (n)? 
```
when there are still outputs to compute if the user answers `u` or `y`.
(cf. lines 531 nd 536)