### PR TITLE
Fix Crash when Calculation of size of deleted dirs is asked for

### DIFF
--- a/sisyphus/cleaner.py
+++ b/sisyphus/cleaner.py
@@ -230,7 +230,7 @@ def remove_directories(dirs, message, move_postfix='.cleanup', mode='remove', fo
             for i in tmp:
                 logging.info(i)
     else:
-        with tempfile.NamedTemporaryFile() as tmp_file:
+        with tempfile.NamedTemporaryFile(mode="w") as tmp_file:
             for directory in dirs:
                 tmp_file.write(directory + "\x00")
             tmp_file.flush()


### PR DESCRIPTION
When calling the current code it crashes with: 

```
Calculate size of affected directories? (Y/n): 
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 tk.cleaner.cleanup_unused(mode="dryrun")

File ~/src/sisyphus/sisyphus/cleaner.py:316, in cleanup_unused(load_from, job_dirs, mode)
    314     job_dirs = list_all_graph_directories()
    315 to_remove = search_for_unused(job_dirs, verbose=True)
--> 316 remove_directories(to_remove, 'Not used in graph', mode=mode, force=False)

File ~/src/sisyphus/sisyphus/cleaner.py:235, in remove_directories(dirs, message, move_postfix, mode, force)
    233 with tempfile.NamedTemporaryFile() as tmp_file:
    234     for directory in dirs:
--> 235         tmp_file.write(directory + "\x00")
    236     tmp_file.flush()
    237     command = 'du -sch --files0-from=%s' % tmp_file.name

File /usr/lib/python3.10/tempfile.py:622, in _TemporaryFileWrapper.__getattr__.<locals>.func_wrapper(*args, **kwargs)
    620 @_functools.wraps(func)
    621 def func_wrapper(*args, **kwargs):
--> 622     return func(*args, **kwargs)

TypeError: a bytes-like object is required, not 'str'

```

This fixes this error. Tbh. I am not sure how this has worked before? 