### PR TITLE
Check for class instances of AbstractPath in extract_paths

### DIFF
--- a/sisyphus/tools.py
+++ b/sisyphus/tools.py
@@ -88,7 +88,7 @@ def extract_paths(args: Any) -> Set:
         if isinstance(obj, Block) or isinstance(obj, enum.Enum):
             continue
         if (hasattr(obj, '_sis_path') and obj._sis_path is True
-            and not (type(obj) is type and issubclass(obj, AbstractPath))):
+                and not (type(obj) is type and issubclass(obj, AbstractPath))):
             out.add(obj)
         elif isinstance(obj, (list, tuple, set)):
             queue.extend(obj)

--- a/sisyphus/tools.py
+++ b/sisyphus/tools.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:
 
 import sisyphus.global_settings as gs
 from sisyphus.block import Block
+from sisyphus.job_path import AbstractPath
 
 
 def get_system_informations(file=sys.stdout):
@@ -86,7 +87,7 @@ def extract_paths(args: Any) -> Set:
         visited_obj_ids[id(obj)] = obj
         if isinstance(obj, Block) or isinstance(obj, enum.Enum):
             continue
-        if hasattr(obj, '_sis_path') and obj._sis_path is True:
+        if hasattr(obj, '_sis_path') and obj._sis_path is True and not (type(obj) is type and issubclass(obj, AbstractPath)):
             out.add(obj)
         elif isinstance(obj, (list, tuple, set)):
             queue.extend(obj)

--- a/sisyphus/tools.py
+++ b/sisyphus/tools.py
@@ -86,7 +86,7 @@ def extract_paths(args: Any) -> Set:
         visited_obj_ids[id(obj)] = obj
         if isinstance(obj, Block) or isinstance(obj, enum.Enum):
             continue
-        if hasattr(obj, '_sis_path') and obj._sis_path is True and not (type(obj) is type:
+        if hasattr(obj, '_sis_path') and obj._sis_path is True and not type(obj) is type:
             out.add(obj)
         elif isinstance(obj, (list, tuple, set)):
             queue.extend(obj)

--- a/sisyphus/tools.py
+++ b/sisyphus/tools.py
@@ -23,7 +23,6 @@ except ModuleNotFoundError:
 
 import sisyphus.global_settings as gs
 from sisyphus.block import Block
-from sisyphus.job_path import AbstractPath
 
 
 def get_system_informations(file=sys.stdout):
@@ -87,8 +86,7 @@ def extract_paths(args: Any) -> Set:
         visited_obj_ids[id(obj)] = obj
         if isinstance(obj, Block) or isinstance(obj, enum.Enum):
             continue
-        if (hasattr(obj, '_sis_path') and obj._sis_path is True
-                and not (type(obj) is type and issubclass(obj, AbstractPath))):
+        if hasattr(obj, '_sis_path') and obj._sis_path is True and not (type(obj) is type:
             out.add(obj)
         elif isinstance(obj, (list, tuple, set)):
             queue.extend(obj)

--- a/sisyphus/tools.py
+++ b/sisyphus/tools.py
@@ -87,7 +87,8 @@ def extract_paths(args: Any) -> Set:
         visited_obj_ids[id(obj)] = obj
         if isinstance(obj, Block) or isinstance(obj, enum.Enum):
             continue
-        if hasattr(obj, '_sis_path') and obj._sis_path is True and not (type(obj) is type and issubclass(obj, AbstractPath)):
+        if (hasattr(obj, '_sis_path') and obj._sis_path is True
+            and not (type(obj) is type and issubclass(obj, AbstractPath))):
             out.add(obj)
         elif isinstance(obj, (list, tuple, set)):
             queue.extend(obj)


### PR DESCRIPTION
For some reason I have a setup where extract_paths will return the class tk.Path. Not sure why that is in my setup, but in principle we should check for that and not return the class itself if it happens to be in the object.