### PR TITLE
slurm engine: allow setting gpu name

### DIFF
--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -137,8 +137,8 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         if rqmt.get('gpu', 0) > 0:
             gres = '--gres=gpu:'
             if rqmt.get('gpu_name', ''):
-                gres += rqmt.get('gpu_name', '') + ':'
-            gres += str(rqmt.get('gpu', 0))
+                gres += rqmt['gpu_name'] + ':'
+            gres += str(rqmt['gpu'])
             out.append(gres)
 
         out.append('--cpus-per-task=%s' % rqmt.get('cpu', 1))

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -135,7 +135,11 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             pass  # there is no option in SLURM?
 
         if rqmt.get('gpu', 0) > 0:
-            out.append('--gres=gpu:%s' % rqmt.get('gpu', 0))
+            gres = '--gres=gpu:'
+            if rqmt.get('gpu_name', ''):
+                gres += rqmt.get('gpu_name', '') + ':'
+            gres += str(rqmt.get('gpu', 0))
+            out.append(gres)
 
         out.append('--cpus-per-task=%s' % rqmt.get('cpu', 1))
 


### PR DESCRIPTION
Sometimes it can be helpful to specify the GPU name even within a given partition for the SLURM engine, e.g., to specify gtx_1080 vs. rtx_2080 in our infrastructure. This PR adds this functionality. To use it, you need to set e.g. `job.rqmt["gpu_name"] = "rtx_2080"`.