### PR TITLE
Fix sys.excepthook_org handling

### DIFF
--- a/sisyphus/loader.py
+++ b/sisyphus/loader.py
@@ -55,7 +55,7 @@ class ConfigManager:
         except SyntaxError:
             import sys
 
-            if gs.USE_VERBOSE_TRACEBACK:
+            if gs.USE_VERBOSE_TRACEBACK and getattr(sys, "excepthook_org", None) is not None:
                 sys.excepthook = sys.excepthook_org
             raise
 


### PR DESCRIPTION
It might not be set, depending on where the exception was raised, and depending on the entry point of Sisyphus.

[Via](https://github.com/rwth-i6/i6_experiments/actions/runs/6219601859/job/16877982502?pr=175):
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/sisyphus-1.0.0-py3.8.egg/sisyphus/loader.py", line 54, in load_config_file
    config = importlib.import_module(module_name)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 10[14](https://github.com/rwth-i6/i6_experiments/actions/runs/6219601859/job/16877982502?pr=175#step:8:15), in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/runner/work/i6_experiments/i6_experiments/config/common/baselines/librispeech.py", line 1, in <module>
    from i6_experiments.common.baselines.librispeech.ls100.gmm.baseline_config import run_librispeech_100_common_baseline
  File "/home/runner/work/i6_experiments/i6_experiments/recipe/i6_experiments/common/baselines/librispeech/ls100/gmm/baseline_config.py", line 6, in <module>
    from i6_experiments.common.setups.rasr import gmm_system
  File "/home/runner/work/i6_experiments/i6_experiments/recipe/i6_experiments/common/setups/rasr/__init__.py", line 1, in <module>
    from .gmm_system import *
  File "/home/runner/work/i6_experiments/i6_experiments/recipe/i6_experiments/common/setups/rasr/gmm_system.py", line 1188
    train_corpus_key=trn_c,
    ^
SyntaxError: keyword argument repeated

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "check_jobs.py", line 10, in <module>
    config_manager.load_configs([function])
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/sisyphus-1.0.0-py3.8.egg/sisyphus/loader.py", line 1[17](https://github.com/rwth-i6/i6_experiments/actions/runs/6219601859/job/16877982502?pr=175#step:8:18), in load_configs
    self.load_config_file(filename)
  File "/opt/hostedtoolcache/Python/3.8.[18](https://github.com/rwth-i6/i6_experiments/actions/runs/6219601859/job/16877982502?pr=175#step:8:19)/x64/lib/python3.8/site-packages/sisyphus-1.0.0-py3.8.egg/sisyphus/loader.py", line 59, in load_config_file
    sys.excepthook = sys.excepthook_org
AttributeError: module 'sys' has no attribute 'excepthook_org'
```