### PR TITLE
use deepcopy for default rqmt

### DIFF
--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -1,6 +1,7 @@
 # Author: Jan-Thorsten Peter <peter@cs.rwth-aachen.de>
 
 import collections
+import copy
 import logging
 import os
 import psutil
@@ -72,7 +73,7 @@ class EngineBase:
         return id_to_rqmt
 
     def add_defaults_to_rqmt(self, task, rqmt):
-        s = self.get_default_rqmt(task).copy()
+        s = copy.deepcopy(self.get_default_rqmt(task))
         s.update(rqmt)
         return s
 


### PR DESCRIPTION
For the case that the `default_rqmt` contains a list (e.g. `default_qsub_args`) we should do a deep rather than a shallow copy.