### PR TITLE
Remove Job assert

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -109,7 +109,6 @@ class JobSingleton(type):
         else:
             # create new object
             job = super(Job, cls).__new__(cls)
-            assert isinstance(job, Job)
             job._sis_tags = tags
 
             # store _sis_id


### PR DESCRIPTION
This line breaks my type checker (Pyright / Pylance) and makes it think that all instances of specific jobs are of the parent class `Job`. e.g.

```
from sisyphus import Job

class MyJob(Job):
    def __init__(self, foo):
        self.foo = foo

my_job = MyJob("foo")
print(my_job.foo)
```
The code works, but type checker complains that `sisyphus.Job` has no member `foo`.

Could we remove this line?