### PR TITLE
Slurm, fix submitting tasks multiple times

### DIFF
--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -259,7 +259,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
 
                 logging.info("Submitted with job_id: %s %s" % (job_id, name))
                 for task_id in range(start_id, end_id, step_size):
-                    self._task_info_cache[(name, task_id)].append((job_id, "PD"))
+                    self._task_info_cache[(name, task_id)].append((job_id, "PENDING"))
 
                 if err:
                     logging.warning(f"Got error while submitting job (but job {job_id} was submitted)")


### PR DESCRIPTION
`submit_helper` writes an invalid state to `_task_info_cache`, and then `task_state` returns `STATE_UNKNOWN`, which causes `STATE_INTERRUPTED_RESUMABLE`, which causes a resubmit.

Fix #163.
