### PR TITLE
Fix worker proc hanging at exception

### DIFF
--- a/sisyphus/worker.py
+++ b/sisyphus/worker.py
@@ -57,7 +57,7 @@ class LoggingThread(Thread):
         self.task = task
         self.task_id = task_id
         self.start_time = None
-        super().__init__()
+        super().__init__(daemon=True)
         self.out_of_memory = False
         self._cond = Condition()
         self.__stop = False
@@ -248,5 +248,8 @@ def worker_helper(args):
     if hasattr(task._job, "_sis_environment") and task._job._sis_environment:
         task._job._sis_environment.modify_environment()
 
-    # run task
-    task.run(task_id, resume_job, logging_thread=logging_thread)
+    try:
+        # run task
+        task.run(task_id, resume_job, logging_thread=logging_thread)
+    finally:
+        logging_thread.stop()


### PR DESCRIPTION
Not all exceptions in Task.run will lead to logging_thread.stop(), which is required that the proc does not hang at exit, because logging_thread was not a daemon thread.

We make it a daemon thread now.
And also, we additionally make extra sure that logging_thread.stop() is called.
(Although there are maybe still other rare cases where this is not effective, so the daemon thread property is still important as well.)

Fix #171.