### PR TITLE
Log finished outputs

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -213,6 +213,9 @@ PRINT_ERROR_LINES = 40
 #: Print message for held jobs
 PRINT_HOLD = True
 
+#: Log for finished outputs.
+FINISHED_LOG = "log/finished.log"
+
 #: Which command should be called to start sisyphus, can be used to replace the python binary
 SIS_COMMAND = [sys.executable, sys.argv[0]]
 # if this first argument is -m it's missing the module name

--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -16,6 +16,7 @@ import pprint
 import threading
 from typing import DefaultDict, Optional, List
 from multiprocessing.pool import ThreadPool
+from datetime import datetime
 
 
 class Node(object):
@@ -112,6 +113,15 @@ class OutputPath(OutputTarget):
                     # Set new link if needed
                     os.symlink(os.path.realpath(self._sis_path.get_path()), outfile_name)
                     logging.info("Finished output: %s" % outfile_name)
+
+                    if gs.FINISHED_LOG:
+                        if "/" in gs.FINISHED_LOG and not os.path.exists(os.path.dirname(gs.FINISHED_LOG)):
+                            os.makedirs(os.path.dirname(gs.FINISHED_LOG))
+                        with open(gs.FINISHED_LOG, "a") as f:
+                            f.write(
+                                datetime.now().strftime("%Y-%m-%d %H:%M:%S: ") + f"Finished output: {outfile_name}\n"
+                            )
+
                 except OSError as e:
                     logging.warning("Failed to updated output %s. Exception: %s" % (outfile_name, e))
 


### PR DESCRIPTION
Fix #152.

I used `FINISHED_LOG` as the name for the option to have it consistent with `MEMORY_PROFILE_LOG`.

I used `"log/finished.log"` as the default path to have it consistent with `"log/manager.log.%s"`
from the manager UI.

I thought about whether to have this enabled or disabled by default, and decided that this should not add too much overhead, so we can have this enabled by default.