### PR TITLE
add quotation marks to --wrap for sbatch

### DIFF
--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -228,7 +228,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
 
         sbatch_call += ["-a", "%i-%i:%i" % (start_id, end_id, step_size)]
         command = '"' + " ".join(call) + '"'
-        sbatch_call += ["--wrap=%s" % " ".join(call)]
+        sbatch_call += ["--wrap='%s'" % " ".join(call)]
         while True:
             try:
                 out, err, retval = self.system_call(sbatch_call)


### PR DESCRIPTION
For some reason calling sbatch would interpret the `--wrap` string differently for one of my new setups.

```
sbatch [...] --wrap=apptainer exec --nv --bind /work/asr4 /work/asr4/rossenbach/rescale/pytorch_mixed_precision/apptainer/u22_pytorch2.1_onnx_flashlight_0224_jaist_project.sif sis worker --engine long work/i6_core/returnn/forward/ReturnnForwardJobV2.xT8obDvtAg1w run
[2024-03-04 10:16:31,705] ERROR: Error: sbatch: error: Script arguments not permitted with --wrap option
```

I added quotation marks solving this issue.

