### PR TITLE
store worker wrapper in Job

### DIFF
--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -211,6 +211,7 @@ class Job(metaclass=JobSingleton):
         self._sis_outputs = {}
         self._sis_keep_value = None
         self._sis_hold_job = False
+        self._sis_worker_wrapper = gs.worker_wrapper
 
         self._sis_blocks = set()
         self._sis_kwargs = parsed_args
@@ -316,6 +317,7 @@ class Job(metaclass=JobSingleton):
             "current_block",
             "_sis_cleanable_cache",
             "_sis_cleaned_or_not_cleanable",
+            "_sis_worker_wrapper",
         ]:
             if key in d:
                 del d[key]

--- a/sisyphus/task.py
+++ b/sisyphus/task.py
@@ -481,5 +481,8 @@ class Task(object):
         call += [gs.CMD_WORKER, os.path.relpath(self.path()), self.name()]
         if task_id is not None:
             call.append(str(task_id))
-        call = gs.worker_wrapper(getattr(self, "_job", None), self.name(), call)
+        if hasattr(self, "_job"):
+            call = self._job._sis_worker_wrapper(self._job, self.name(), call)
+        else:
+            call = gs.worker_wrapper(None, self.name(), call)
         return call

--- a/sisyphus/task.py
+++ b/sisyphus/task.py
@@ -484,5 +484,6 @@ class Task(object):
         if hasattr(self, "_job"):
             call = self._job._sis_worker_wrapper(self._job, self.name(), call)
         else:
+            logging.warning(f"Task {self.name()} run without an associated Job. Using global worker_wrapper.")
             call = gs.worker_wrapper(None, self.name(), call)
         return call


### PR DESCRIPTION
In on of our setups we wanted to use different worker wrapper functions for different parts of the setup.

Therefore I propose to store the currently defined `gs.worker_wrapper` at the creation time of the Job in the Job. Then different parts of the setup can change the worker_wrapper as they go.