### PR TITLE
Keep hash consistent for enum in newer Python versions

### DIFF
--- a/sisyphus/hash.py
+++ b/sisyphus/hash.py
@@ -64,7 +64,8 @@ def get_object_state(obj):
 
     if isinstance(obj, enum.Enum):
         assert isinstance(state, dict)
-        state.pop("_sort_order_", None)  # compat with Python <=3.10, https://github.com/rwth-i6/sisyphus/issues/188
+        # In Python >=3.11, keep hash same as in Python <=3.10, https://github.com/rwth-i6/sisyphus/issues/188
+        state.pop("_sort_order_", None)
 
     if args is None:
         return state
@@ -125,5 +126,6 @@ def sis_hash_helper(obj):
 
 def _obj_type_qualname(obj) -> bytes:
     if type(obj) is enum.EnumMeta:  # EnumMeta is old alias for EnumType
-        return b"EnumMeta"  # compat with Python <=3.10, https://github.com/rwth-i6/sisyphus/issues/188
+        # In Python >=3.11, keep hash same as in Python <=3.10, https://github.com/rwth-i6/sisyphus/issues/188
+        return b"EnumMeta"
     return type(obj).__qualname__.encode()

--- a/tests/hash_unittest.py
+++ b/tests/hash_unittest.py
@@ -7,6 +7,11 @@ def b():
     pass
 
 
+class MyEnum(enum.Enum):
+    Entry0 = 0
+    Entry1 = 1
+
+
 class HashTest(unittest.TestCase):
     def test_get_object_state(self):
 
@@ -17,6 +22,15 @@ class HashTest(unittest.TestCase):
 
         self.assertEqual(sis_hash_helper(b), b"(function, (tuple, (str, '" + __name__.encode() + b"'), (str, 'b')))")
         self.assertRaises(AssertionError, sis_hash_helper, c)
+
+    def test_enum(self):
+        self.assertEqual(
+            sis_hash_helper(MyEnum.Entry1),
+            b"(%s, (dict, (tuple, (str, '__objclass__')," % MyEnum.__name__.encode()
+            + b" (EnumMeta, (tuple, (str, '%s'), (str, '%s')))),"
+            % (MyEnum.__module__.encode(), MyEnum.__name__.encode())
+            + b" (tuple, (str, '_name_'), (str, 'Entry1')), (tuple, (str, '_value_'), (int, 1))))",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #188.
