### PR TITLE
Add timeout to SSH queue scan command

### DIFF
--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -91,7 +91,7 @@ class AWSBatchEngine(EngineBase):
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
         p = subprocess.run(
-            system_command, stdin=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
+            system_command, input=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
         )
 
         def fix_output(o):

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -94,6 +94,7 @@ class AWSBatchEngine(EngineBase):
             p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
         except subprocess.TimeoutExpired:
             logging.warning("Timeout expired for command: %s" % " ".join(system_command))
+            return [], ["TimeoutExpired"], -1
 
         def fix_output(o):
             """

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -1,4 +1,4 @@
-""" This is an experimental implementation for the aws batch engine.
+"""This is an experimental implementation for the aws batch engine.
 
 WARNING: After running some setups I can currently not recommend using aws batch with Sisyphus.
 AWS parallelcluster (https://aws.amazon.com/blogs/opensource/aws-parallelcluster/) looks like a easy way how
@@ -90,7 +90,10 @@ class AWSBatchEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        try:
+            p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            logging.warning("Timeout expired for command: %s" % " ".join(system_command))
 
         def fix_output(o):
             """

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -90,9 +90,7 @@ class AWSBatchEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(
-            system_command, input=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
-        )
+        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
 
         def fix_output(o):
             """

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -88,10 +88,11 @@ class AWSBatchEngine(EngineBase):
         system_command = command
 
         logging.debug("shell_cmd: %s" % " ".join(system_command))
-        p = subprocess.Popen(system_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        out, err = p.communicate(input=send_to_stdin, timeout=30)
+        p = subprocess.run(
+            system_command, stdin=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
+        )
 
         def fix_output(o):
             """
@@ -105,9 +106,9 @@ class AWSBatchEngine(EngineBase):
                 assert False
             return o[:-1]
 
-        out = fix_output(out)
-        err = fix_output(err)
-        retval = p.wait(timeout=30)
+        out = fix_output(p.stdout)
+        err = fix_output(p.stderr)
+        retval = p.returncode
 
         return out, err, retval
 

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -59,7 +59,7 @@ class LoadSharingFacilityEngine(EngineBase):
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
         p = subprocess.run(
-            system_command, stdin=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
+            system_command, input=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
         )
 
         def fix_output(o):

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -62,6 +62,7 @@ class LoadSharingFacilityEngine(EngineBase):
             p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
         except subprocess.TimeoutExpired:
             logging.warning("Timeout expired for command: %s" % " ".join(system_command))
+            return [], ["TimeoutExpired"], -1
 
         def fix_output(o):
             # split output and drop last empty line

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -58,7 +58,10 @@ class LoadSharingFacilityEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        try:
+            p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            logging.warning("Timeout expired for command: %s" % " ".join(system_command))
 
         def fix_output(o):
             # split output and drop last empty line

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -58,9 +58,7 @@ class LoadSharingFacilityEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(
-            system_command, input=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
-        )
+        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
 
         def fix_output(o):
             # split output and drop last empty line

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -56,10 +56,11 @@ class LoadSharingFacilityEngine(EngineBase):
             system_command = command
 
         logging.debug("shell_cmd: %s" % " ".join(system_command))
-        p = subprocess.Popen(system_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        out, err = p.communicate(input=send_to_stdin, timeout=30)
+        p = subprocess.run(
+            system_command, stdin=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
+        )
 
         def fix_output(o):
             # split output and drop last empty line
@@ -69,9 +70,9 @@ class LoadSharingFacilityEngine(EngineBase):
                 assert False
             return o[:-1]
 
-        out = fix_output(out)
-        err = fix_output(err)
-        retval = p.wait(timeout=30)
+        out = fix_output(p.stdout)
+        err = fix_output(p.stderr)
+        retval = p.returncode
 
         # Check for ssh error
         err_ = []

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -97,7 +97,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
         p = subprocess.run(
-            system_command, stdin=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
+            system_command, input=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
         )
 
         def fix_output(o):

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -86,7 +86,9 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         """
         if self.gateway:
             escaped_command = [shlex.quote(s) for s in command]  # parameters need to be shell safe when sending via ssh
-            system_command = ["ssh", "-x", self.gateway] + [" ".join(["cd", os.getcwd(), "&&"] + escaped_command)]
+            system_command = ["ssh", "-x", self.gateway, "-o", "ConnectTimeout", gs.WAIT_PERIOD_BETWEEN_CHECKS] + [
+                " ".join(["cd", os.getcwd(), "&&"] + escaped_command)
+            ]
         else:
             # no gateway given, skip ssh local
             system_command = command
@@ -95,7 +97,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         p = subprocess.Popen(system_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        out, err = p.communicate(input=send_to_stdin, timeout=30)
+        out, err = p.communicate(input=send_to_stdin, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
 
         def fix_output(o):
             """
@@ -289,7 +291,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
     def queue_state(self):
         """Returns list with all currently running tasks in this queue"""
 
-        if time.time() - self._task_info_cache_last_update < 30:
+        if time.time() - self._task_info_cache_last_update < gs.WAIT_PERIOD_BETWEEN_CHECKS:
             # use cached value
             return self._task_info_cache
 

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -99,8 +99,6 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         p = subprocess.run(
             system_command,
             stdin=send_to_stdin,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS,
         )
 

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -100,6 +100,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
         except subprocess.TimeoutExpired:
             logging.warning("Timeout expired for command: %s" % " ".join(system_command))
+            return [], ["TimeoutExpired"], -1
 
         def fix_output(o):
             """

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -96,11 +96,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(
-            system_command,
-            stdin=send_to_stdin,
-            timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS,
-        )
+        p = subprocess.run(system_command, stdin=send_to_stdin, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
 
         def fix_output(o):
             """

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -96,7 +96,9 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(system_command, stdin=send_to_stdin, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
+        p = subprocess.run(
+            system_command, stdin=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
+        )
 
         def fix_output(o):
             """

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -96,9 +96,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(
-            system_command, input=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
-        )
+        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
 
         def fix_output(o):
             """
@@ -292,7 +290,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
     def queue_state(self):
         """Returns list with all currently running tasks in this queue"""
 
-        if time.time() - self._task_info_cache_last_update < gs.WAIT_PERIOD_BETWEEN_CHECKS:
+        if time.time() - self._task_info_cache_last_update < 30:
             # use cached value
             return self._task_info_cache
 

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -86,7 +86,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         """
         if self.gateway:
             escaped_command = [shlex.quote(s) for s in command]  # parameters need to be shell safe when sending via ssh
-            system_command = ["ssh", "-x", self.gateway, "-o", "ConnectTimeout", gs.WAIT_PERIOD_BETWEEN_CHECKS] + [
+            system_command = ["ssh", "-x", self.gateway, "-o", "BatchMode=yes"] + [
                 " ".join(["cd", os.getcwd(), "&&"] + escaped_command)
             ]
         else:
@@ -116,9 +116,9 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
                 assert False
             return o[:-1]
 
-        out = fix_output(out)
-        err = fix_output(err)
-        retval = p.wait(timeout=30)
+        out = fix_output(p.stdout)
+        err = fix_output(p.stderr)
+        retval = p.returncode
 
         # Check for ssh error
         err_ = []

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -96,7 +96,10 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        try:
+            p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            logging.warning("Timeout expired for command: %s" % " ".join(system_command))
 
         def fix_output(o):
             """

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -94,10 +94,15 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             system_command = command
 
         logging.debug("shell_cmd: %s" % " ".join(system_command))
-        p = subprocess.Popen(system_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        out, err = p.communicate(input=send_to_stdin, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
+        p = subprocess.run(
+            system_command,
+            stdin=send_to_stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS,
+        )
 
         def fix_output(o):
             """

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -97,11 +97,7 @@ class SonOfGridEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(
-            system_command,
-            stdin=send_to_stdin,
-            timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS,
-        )
+        p = subprocess.run(system_command, stdin=send_to_stdin, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
 
         def fix_output(o):
             """

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -95,10 +95,15 @@ class SonOfGridEngine(EngineBase):
             system_command = command
 
         logging.debug("shell_cmd: %s" % " ".join(system_command))
-        p = subprocess.Popen(system_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        out, err = p.communicate(input=send_to_stdin, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
+        p = subprocess.run(
+            system_command,
+            stdin=send_to_stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS,
+        )
 
         def fix_output(o):
             """

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -100,8 +100,6 @@ class SonOfGridEngine(EngineBase):
         p = subprocess.run(
             system_command,
             stdin=send_to_stdin,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS,
         )
 

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -97,7 +97,10 @@ class SonOfGridEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        try:
+            p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            logging.warning("Timeout expired for command: %s" % " ".join(system_command))
 
         def fix_output(o):
             """

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -97,7 +97,9 @@ class SonOfGridEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(system_command, stdin=send_to_stdin, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
+        p = subprocess.run(
+            system_command, stdin=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
+        )
 
         def fix_output(o):
             """

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -97,9 +97,7 @@ class SonOfGridEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        p = subprocess.run(
-            system_command, input=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
-        )
+        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
 
         def fix_output(o):
             """
@@ -310,7 +308,7 @@ class SonOfGridEngine(EngineBase):
     def queue_state(self):
         """Return s list with all currently running tasks in this queue"""
 
-        if time.time() - self._task_info_cache_last_update < gs.WAIT_PERIOD_BETWEEN_CHECKS:
+        if time.time() - self._task_info_cache_last_update < 30:
             # use cached value
             return self._task_info_cache
 

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -98,7 +98,7 @@ class SonOfGridEngine(EngineBase):
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
         p = subprocess.run(
-            system_command, stdin=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
+            system_command, input=send_to_stdin, capture_output=True, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS
         )
 
         def fix_output(o):

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -87,7 +87,9 @@ class SonOfGridEngine(EngineBase):
         :rtype: list[bytes], list[bytes], int
         """
         if self.gateway:
-            system_command = ["ssh", "-x", self.gateway] + [" ".join(["cd", os.getcwd(), "&&"] + command)]
+            system_command = ["ssh", "-x", self.gateway, "-o", "ConnectTimeout", gs.WAIT_PERIOD_BETWEEN_CHECKS] + [
+                " ".join(["cd", os.getcwd(), "&&"] + command)
+            ]
         else:
             # no gateway given, skip ssh local
             system_command = command
@@ -96,7 +98,7 @@ class SonOfGridEngine(EngineBase):
         p = subprocess.Popen(system_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        out, err = p.communicate(input=send_to_stdin, timeout=30)
+        out, err = p.communicate(input=send_to_stdin, timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
 
         def fix_output(o):
             """
@@ -112,7 +114,7 @@ class SonOfGridEngine(EngineBase):
 
         out = fix_output(out)
         err = fix_output(err)
-        retval = p.wait(timeout=30)
+        retval = p.wait(timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
 
         # Check for ssh error
         err_ = []
@@ -307,7 +309,7 @@ class SonOfGridEngine(EngineBase):
     def queue_state(self):
         """Return s list with all currently running tasks in this queue"""
 
-        if time.time() - self._task_info_cache_last_update < 30:
+        if time.time() - self._task_info_cache_last_update < gs.WAIT_PERIOD_BETWEEN_CHECKS:
             # use cached value
             return self._task_info_cache
 

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -87,7 +87,7 @@ class SonOfGridEngine(EngineBase):
         :rtype: list[bytes], list[bytes], int
         """
         if self.gateway:
-            system_command = ["ssh", "-x", self.gateway, "-o", "ConnectTimeout", gs.WAIT_PERIOD_BETWEEN_CHECKS] + [
+            system_command = ["ssh", "-x", self.gateway, "-o", "BatchMode=yes"] + [
                 " ".join(["cd", os.getcwd(), "&&"] + command)
             ]
         else:
@@ -117,9 +117,9 @@ class SonOfGridEngine(EngineBase):
                 assert False
             return o[:-1]
 
-        out = fix_output(out)
-        err = fix_output(err)
-        retval = p.wait(timeout=gs.WAIT_PERIOD_BETWEEN_CHECKS)
+        out = fix_output(p.stdout)
+        err = fix_output(p.stderr)
+        retval = p.returncode
 
         # Check for ssh error
         err_ = []

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -101,6 +101,7 @@ class SonOfGridEngine(EngineBase):
             p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
         except subprocess.TimeoutExpired:
             logging.warning("Timeout expired for command: %s" % " ".join(system_command))
+            return [], ["TimeoutExpired"], -1
 
         def fix_output(o):
             """


### PR DESCRIPTION
If the SSH key isn't properly set, sisyphus will schedule stacked queue scan commands which will ask for a password. This will lead to subprocess buildup, which eventually crashes the manager with a `Too many open files` error.

I've also changed the hardcoded 30 second interval for an interval depending on `gs.WAIT_PERIOD_BETWEEN_CHECKS`, which I find makes more sense. <- Edit: not anymore, see below.

Fix #190.