### PR TITLE
Catch `subprocess.TimeoutError` once

### DIFF
--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -90,11 +90,8 @@ class AWSBatchEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        try:
-            p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
-        except subprocess.TimeoutExpired:
-            logging.warning("Timeout expired for command: %s" % " ".join(system_command))
-            return [], ["TimeoutExpired".encode()], -1
+
+        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
 
         def fix_output(o):
             """

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -58,11 +58,8 @@ class LoadSharingFacilityEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        try:
-            p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
-        except subprocess.TimeoutExpired:
-            logging.warning(self._system_call_timeout_warn_msg(system_command))
-            return [], ["TimeoutExpired".encode()], -1
+        
+        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
 
         def fix_output(o):
             # split output and drop last empty line
@@ -189,8 +186,10 @@ class LoadSharingFacilityEngine(EngineBase):
         while True:
             logging.info("bsub_call: %s" % bsub_call)
             logging.info("command: %s" % command)
-            out, err, retval = self.system_call(bsub_call, command)
-            if retval != 0:
+            try:
+                out, err, retval = self.system_call(bsub_call, command)
+            except subprocess.TimeoutExpired:
+                logging.warning(self._system_call_timeout_warn_msg(bsub_call))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
                 continue
             break
@@ -248,8 +247,10 @@ class LoadSharingFacilityEngine(EngineBase):
         # get bjobs output
         system_command = ["bjobs", "-w"]
         while True:
-            out, err, retval = self.system_call(system_command)
-            if retval != 0:
+            try:
+                out, err, retval = self.system_call(system_command)
+            except subprocess.TimeoutExpired:
+                logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
                 continue
             break

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -61,7 +61,7 @@ class LoadSharingFacilityEngine(EngineBase):
         try:
             p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
         except subprocess.TimeoutExpired:
-            logging.warning("Timeout expired for command: %s" % " ".join(system_command))
+            logging.warning(self._system_call_timeout_warn_msg(system_command))
             return [], ["TimeoutExpired".encode()], -1
 
         def fix_output(o):
@@ -187,12 +187,10 @@ class LoadSharingFacilityEngine(EngineBase):
         )
 
         while True:
-            try:
-                logging.info("bsub_call: %s" % bsub_call)
-                logging.info("command: %s" % command)
-                out, err, retval = self.system_call(bsub_call, command)
-            except subprocess.TimeoutExpired:
-                logging.warning(self._system_call_timeout_warn_msg(command))
+            logging.info("bsub_call: %s" % bsub_call)
+            logging.info("command: %s" % command)
+            out, err, retval = self.system_call(bsub_call, command)
+            if retval != 0:
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
                 continue
             break
@@ -250,10 +248,8 @@ class LoadSharingFacilityEngine(EngineBase):
         # get bjobs output
         system_command = ["bjobs", "-w"]
         while True:
-            try:
-                out, err, retval = self.system_call(system_command)
-            except subprocess.TimeoutExpired:
-                logging.warning(self._system_call_timeout_warn_msg(system_command))
+            out, err, retval = self.system_call(system_command)
+            if retval != 0:
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
                 continue
             break

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -58,7 +58,7 @@ class LoadSharingFacilityEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        
+
         p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
 
         def fix_output(o):

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -96,11 +96,8 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         logging.debug("shell_cmd: %s" % " ".join(system_command))
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
-        try:
-            p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
-        except subprocess.TimeoutExpired:
-            logging.warning(self._system_call_timeout_warn_msg(system_command))
-            return [], ["TimeoutExpired".encode()], -1
+
+        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
 
         def fix_output(o):
             """
@@ -236,8 +233,10 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         sbatch_call += ["-a", "%i-%i:%i" % (start_id, end_id, step_size)]
         sbatch_call += ["--wrap=%s" % " ".join(call)]
         while True:
-            out, err, retval = self.system_call(sbatch_call)
-            if retval != 0:
+            try:
+                out, err, retval = self.system_call(sbatch_call)
+            except subprocess.TimeoutExpired:
+                logging.warning(self._system_call_timeout_warn_msg(sbatch_call))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
                 continue
             break
@@ -306,8 +305,10 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             "arrayjobid,arraytaskid,state,name:1000",
         ]
         while True:
-            out, err, retval = self.system_call(system_command)
-            if retval != 0:
+            try:
+                out, err, retval = self.system_call(system_command)
+            except subprocess.TimeoutExpired:
+                logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
                 continue
             break

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -100,7 +100,7 @@ class SonOfGridEngine(EngineBase):
         try:
             p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
         except subprocess.TimeoutExpired:
-            logging.warning("Timeout expired for command: %s" % " ".join(system_command))
+            logging.warning(self._system_call_timeout_warn_msg(system_command))
             return [], ["TimeoutExpired".encode()], -1
 
         def fix_output(o):
@@ -252,10 +252,8 @@ class SonOfGridEngine(EngineBase):
         qsub_call += ["-t", "%i-%i:%i" % (start_id, end_id, step_size)]
         command = " ".join(call) + "\n"
         while True:
-            try:
-                out, err, retval = self.system_call(qsub_call, command)
-            except subprocess.TimeoutExpired:
-                logging.warning(self._system_call_timeout_warn_msg(command))
+            out, err, retval = self.system_call(qsub_call, command)
+            if retval != 0:
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
                 continue
             break
@@ -319,10 +317,8 @@ class SonOfGridEngine(EngineBase):
         # get qstat output
         system_command = ["qstat", "-xml", "-u", getpass.getuser()]
         while True:
-            try:
-                out, err, retval = self.system_call(system_command)
-            except subprocess.TimeoutExpired:
-                logging.warning(self._system_call_timeout_warn_msg(system_command))
+            out, err, retval = self.system_call(system_command)
+            if retval != 0:
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
                 continue
             break


### PR DESCRIPTION
This was the root cause of several jobs with the same features being submitted, even though they had already been submitted:

1. We use the `gateway` option and there's a `TimeoutError` [here](https://github.com/rwth-i6/sisyphus/blob/master/sisyphus/simple_linux_utility_for_resource_management_engine.py#L101).
2. From the point of view of sisyphus, the `ssh gw-02 squeue` finishes with error -1. Sisyphus then reaches [here](https://github.com/rwth-i6/sisyphus/blob/master/sisyphus/simple_linux_utility_for_resource_management_engine.py#L241) safely. It hasn't crashed with a `TimeoutError` because we haven't propagated it.
3. No `TimeoutError` is raised after calling `self.system_call()` because it's already been addressed inside `self.system_call()` and it hasn't been propagated. Therefore, the process ignores the `except` block [here](https://github.com/rwth-i6/sisyphus/blob/master/sisyphus/simple_linux_utility_for_resource_management_engine.py#L242). If `retval == -1`, sisyphus doesn't care either!

In my view, the problem comes from not addressing errors that could have been obtained from the return values. Therefore, this PR correctly addresses return codes different from zero, and leaves the work of addressing the exceptions of the subprocesses to `self.system_call()`.