### PR TITLE
Queue scan: handle return value different from zero

### DIFF
--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -235,7 +235,7 @@ class AWSBatchEngine(EngineBase):
         if qs == "FAILED":
             return STATE_QUEUE_ERROR
         logging.warning("Unknown AWS engine state %s" % qs)
-        return STATE_UNKNOWN
+        return STATE_QUEUE_ERROR
 
     def start_engine(self):
         """No starting action required with the current implementation"""

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -26,7 +26,7 @@ from collections import namedtuple
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNABLE, STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
+from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "aws"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -26,7 +26,7 @@ from collections import namedtuple
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
+from sisyphus.global_settings import STATE_RUNNABLE, STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "aws"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])
@@ -225,7 +225,7 @@ class AWSBatchEngine(EngineBase):
         try:
             queue_state = self.queue_state()
         except subprocess.CalledProcessError:
-            return STATE_QUEUE_ERROR
+            return STATE_RUNNABLE
         qs = queue_state.get(task_name)
 
         # task name should be uniq

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -222,7 +222,10 @@ class AWSBatchEngine(EngineBase):
         """Return task state:"""
         name = task.task_name()
         task_name = escape_name(name, task_id)
-        queue_state = self.queue_state()
+        try:
+            queue_state = self.queue_state()
+        except subprocess.CalledProcessError:
+            return STATE_QUEUE_ERROR
         qs = queue_state.get(task_name)
 
         # task name should be uniq

--- a/sisyphus/aws_batch_engine.py
+++ b/sisyphus/aws_batch_engine.py
@@ -222,10 +222,7 @@ class AWSBatchEngine(EngineBase):
         """Return task state:"""
         name = task.task_name()
         task_name = escape_name(name, task_id)
-        try:
-            queue_state = self.queue_state()
-        except subprocess.CalledProcessError:
-            return STATE_RUNNABLE
+        queue_state = self.queue_state()
         qs = queue_state.get(task_name)
 
         # task name should be uniq

--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -218,9 +218,9 @@ class EngineSelector(EngineBase):
         """
         assert isinstance(default_engine, str), "default_engine must be a string: %r" % (default_engine,)
         for k, v in engines.items():
-            assert isinstance(k, str) and isinstance(v, EngineBase), (
-                "engines must only contain strings as keys and Engines as value: (%r, %r)" % (k, v)
-            )
+            assert isinstance(k, str) and isinstance(
+                v, EngineBase
+            ), "engines must only contain strings as keys and Engines as value: (%r, %r)" % (k, v)
         self.engines = engines
         self.default_engine = default_engine
 

--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -218,9 +218,9 @@ class EngineSelector(EngineBase):
         """
         assert isinstance(default_engine, str), "default_engine must be a string: %r" % (default_engine,)
         for k, v in engines.items():
-            assert isinstance(k, str) and isinstance(
-                v, EngineBase
-            ), "engines must only contain strings as keys " "and Engines as value: (%r, %r)" % (k, v)
+            assert isinstance(k, str) and isinstance(v, EngineBase), (
+                "engines must only contain strings as keys and Engines as value: (%r, %r)" % (k, v)
+            )
         self.engines = engines
         self.default_engine = default_engine
 

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -11,7 +11,7 @@ from collections import defaultdict, namedtuple
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNABLE, STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
+from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "lsf"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -195,7 +195,7 @@ class LoadSharingFacilityEngine(EngineBase):
                 out, err, retval = self.system_call(bsub_call, command)
                 if retval != 0:
                     logging.warning(self._system_call_error_warn_msg(bsub_call))
-                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
                     continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(bsub_call))
@@ -260,7 +260,7 @@ class LoadSharingFacilityEngine(EngineBase):
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
                     logging.warning(self._system_call_error_warn_msg(system_command))
-                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
                     continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -193,10 +193,6 @@ class LoadSharingFacilityEngine(EngineBase):
             logging.info("command: %s" % command)
             try:
                 out, err, retval = self.system_call(bsub_call, command)
-                if retval != 0:
-                    logging.warning(self._system_call_error_warn_msg(bsub_call))
-                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
-                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(bsub_call))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -255,9 +255,7 @@ class LoadSharingFacilityEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    logging.warning(self._system_call_error_warn_msg(system_command))
-                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
-                    continue
+                    raise subprocess.CalledProcessError(self._system_call_error_warn_msg(system_command))
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -292,7 +290,10 @@ class LoadSharingFacilityEngine(EngineBase):
         name = task.task_name()
         name = escape_name(name).encode()
         task_name = (name, task_id)
-        queue_state = self.queue_state()
+        try:
+            queue_state = self.queue_state()
+        except subprocess.CalledProcessError:
+            return STATE_QUEUE_ERROR
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -255,7 +255,7 @@ class LoadSharingFacilityEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(self._system_call_error_warn_msg(system_command))
+                    raise subprocess.CalledProcessError(retval, self._system_call_error_warn_msg(system_command))
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -48,6 +48,11 @@ class LoadSharingFacilityEngine(EngineBase):
             return f"SSH command timeout: {command!s}"
         return f"Command timeout: {command!s}"
 
+    def _system_call_error_warn_msg(self, command: Any) -> str:
+        if self.gateway:
+            return f"SSH command error: {command!s}"
+        return f"Command error: {command!s}"
+
     def system_call(self, command, send_to_stdin=None):
         if self.gateway:
             system_command = ["ssh", "-x", self.gateway] + [" ".join(["cd", os.getcwd(), "&&"] + command)]
@@ -188,6 +193,10 @@ class LoadSharingFacilityEngine(EngineBase):
             logging.info("command: %s" % command)
             try:
                 out, err, retval = self.system_call(bsub_call, command)
+                if retval != 0:
+                    logging.warning(self._system_call_error_warn_msg(bsub_call))
+                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(bsub_call))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -249,6 +258,10 @@ class LoadSharingFacilityEngine(EngineBase):
         while True:
             try:
                 out, err, retval = self.system_call(system_command)
+                if retval != 0:
+                    logging.warning(self._system_call_error_warn_msg(system_command))
+                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -255,9 +255,9 @@ class LoadSharingFacilityEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(
-                        retval, system_command, self._system_call_error_warn_msg(system_command)
-                    )
+                    logging.warning(self._system_call_error_warn_msg(system_command))
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -292,10 +292,7 @@ class LoadSharingFacilityEngine(EngineBase):
         name = task.task_name()
         name = escape_name(name).encode()
         task_name = (name, task_id)
-        try:
-            queue_state = self.queue_state()
-        except subprocess.CalledProcessError:
-            return STATE_RUNNABLE
+        queue_state = self.queue_state()
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -255,7 +255,9 @@ class LoadSharingFacilityEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(retval, self._system_call_error_warn_msg(system_command))
+                    raise subprocess.CalledProcessError(
+                        retval, system_command, self._system_call_error_warn_msg(system_command)
+                    )
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/load_sharing_facility_engine.py
+++ b/sisyphus/load_sharing_facility_engine.py
@@ -11,7 +11,7 @@ from collections import defaultdict, namedtuple
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
+from sisyphus.global_settings import STATE_RUNNABLE, STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "lsf"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])
@@ -295,7 +295,7 @@ class LoadSharingFacilityEngine(EngineBase):
         try:
             queue_state = self.queue_state()
         except subprocess.CalledProcessError:
-            return STATE_QUEUE_ERROR
+            return STATE_RUNNABLE
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/localengine.py
+++ b/sisyphus/localengine.py
@@ -39,7 +39,6 @@ def get_process_logging_path(task_path, task_name, task_id):
 
 
 class sync_object(object):
-
     """Object to be used by the with statement to sync an object via queue
     e.g.::
 
@@ -66,7 +65,6 @@ class sync_object(object):
 
 
 class LocalEngine(threading.Thread, EngineBase):
-
     """Simple engine to execute running tasks locally.
     CPU and GPU are always checked, all other requirements only if given during initialisation.
     """

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -13,7 +13,7 @@ import time
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNABLE, STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
+from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "slurm"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -242,7 +242,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
                 out, err, retval = self.system_call(sbatch_call)
                 if retval != 0:
                     logging.warning(self._system_call_error_warn_msg(sbatch_call))
-                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
                     continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(sbatch_call))
@@ -318,7 +318,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
                     logging.warning(self._system_call_error_warn_msg(system_command))
-                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
                     continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -313,7 +313,9 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(retval, self._system_call_error_warn_msg(system_command))
+                    raise subprocess.CalledProcessError(
+                        retval, system_command, self._system_call_error_warn_msg(system_command)
+                    )
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -313,9 +313,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    logging.warning(self._system_call_error_warn_msg(system_command))
-                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
-                    continue
+                    raise subprocess.CalledProcessError(self._system_call_error_warn_msg(system_command))
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -350,7 +348,10 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         name = task.task_name()
         name = self.process_task_name(name)
         task_name = (name, task_id)
-        queue_state = self.queue_state()
+        try:
+            queue_state = self.queue_state()
+        except subprocess.CalledProcessError:
+            return STATE_QUEUE_ERROR
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -317,7 +317,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    logging.warning(self._system_call_error_warn_msg(sbatch_call))
+                    logging.warning(self._system_call_error_warn_msg(system_command))
                     time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
                     continue
             except subprocess.TimeoutExpired:

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -13,7 +13,7 @@ import time
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE
+from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "slurm"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])
@@ -367,7 +367,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         elif state in ["PENDING", "CONFIGURING"]:
             return STATE_QUEUE
         else:
-            return STATE_UNKNOWN
+            return STATE_QUEUE_ERROR
 
     def start_engine(self):
         """No starting action required with the current implementation"""

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -313,7 +313,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(self._system_call_error_warn_msg(system_command))
+                    raise subprocess.CalledProcessError(retval, self._system_call_error_warn_msg(system_command))
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -77,6 +77,11 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             return f"SSH command timeout: {command!s}"
         return f"Command timeout: {command!s}"
 
+    def _system_call_error_warn_msg(self, command: Any) -> str:
+        if self.gateway:
+            return f"SSH command error: {command!s}"
+        return f"Command error: {command!s}"
+
     def system_call(self, command, send_to_stdin=None):
         """
         :param list[str] command: qsub command
@@ -235,6 +240,10 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         while True:
             try:
                 out, err, retval = self.system_call(sbatch_call)
+                if retval != 0:
+                    logging.warning(self._system_call_error_warn_msg(sbatch_call))
+                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(sbatch_call))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -307,6 +316,10 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         while True:
             try:
                 out, err, retval = self.system_call(system_command)
+                if retval != 0:
+                    logging.warning(self._system_call_error_warn_msg(sbatch_call))
+                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -13,7 +13,7 @@ import time
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
+from sisyphus.global_settings import STATE_RUNNABLE, STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "slurm"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])
@@ -353,7 +353,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         try:
             queue_state = self.queue_state()
         except subprocess.CalledProcessError:
-            return STATE_QUEUE_ERROR
+            return STATE_RUNNABLE
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -240,10 +240,6 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         while True:
             try:
                 out, err, retval = self.system_call(sbatch_call)
-                if retval != 0:
-                    logging.warning(self._system_call_error_warn_msg(sbatch_call))
-                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
-                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(sbatch_call))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -313,9 +313,9 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(
-                        retval, system_command, self._system_call_error_warn_msg(system_command)
-                    )
+                    logging.warning(self._system_call_error_warn_msg(system_command))
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -350,10 +350,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         name = task.task_name()
         name = self.process_task_name(name)
         task_name = (name, task_id)
-        try:
-            queue_state = self.queue_state()
-        except subprocess.CalledProcessError:
-            return STATE_RUNNABLE
+        queue_state = self.queue_state()
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -1,5 +1,6 @@
 # Author: Jan-Thorsten Peter <peter@cs.rwth-aachen.de>
 
+from typing import Any
 import os
 import subprocess
 
@@ -72,6 +73,16 @@ class SonOfGridEngine(EngineBase):
             ignore_jobs = []
         self.ignore_jobs = ignore_jobs
         self.pe_name = pe_name
+
+    def _system_call_timeout_warn_msg(self, command: Any) -> str:
+        if self.gateway:
+            return f"SSH command timeout: {command!s}"
+        return f"Command timeout: {command!s}"
+
+    def _system_call_error_warn_msg(self, command: Any) -> str:
+        if self.gateway:
+            return f"SSH command error: {command!s}"
+        return f"Command error: {command!s}"
 
     def system_call(self, command, send_to_stdin=None):
         """

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -324,7 +324,9 @@ class SonOfGridEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(retval, self._system_call_error_warn_msg(system_command))
+                    raise subprocess.CalledProcessError(
+                        retval, system_command, self._system_call_error_warn_msg(system_command)
+                    )
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -1,6 +1,5 @@
 # Author: Jan-Thorsten Peter <peter@cs.rwth-aachen.de>
 
-from typing import Any
 import os
 import subprocess
 
@@ -73,16 +72,6 @@ class SonOfGridEngine(EngineBase):
             ignore_jobs = []
         self.ignore_jobs = ignore_jobs
         self.pe_name = pe_name
-
-    def _system_call_timeout_warn_msg(self, command: Any) -> str:
-        if self.gateway:
-            return f"SSH command timeout: {command!s}"
-        return f"Command timeout: {command!s}"
-
-    def _system_call_error_warn_msg(self, command: Any) -> str:
-        if self.gateway:
-            return f"SSH command error: {command!s}"
-        return f"Command error: {command!s}"
 
     def system_call(self, command, send_to_stdin=None):
         """
@@ -258,7 +247,7 @@ class SonOfGridEngine(EngineBase):
                 out, err, retval = self.system_call(qsub_call, command)
                 if retval != 0:
                     logging.warning(self._system_call_error_warn_msg(qsub_call))
-                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
                     continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(qsub_call))
@@ -329,7 +318,7 @@ class SonOfGridEngine(EngineBase):
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
                     logging.warning(self._system_call_error_warn_msg(system_command))
-                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
                     continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -324,9 +324,7 @@ class SonOfGridEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    logging.warning(self._system_call_error_warn_msg(system_command))
-                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
-                    continue
+                    raise subprocess.CalledProcessError(self._system_call_error_warn_msg(system_command))
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -416,7 +414,10 @@ class SonOfGridEngine(EngineBase):
         name = task.task_name()
         name = escape_name(name)
         task_name = (name, task_id)
-        queue_state = self.queue_state()
+        try:
+            queue_state = self.queue_state()
+        except subprocess.CalledProcessError:
+            return STATE_QUEUE_ERROR
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -324,7 +324,7 @@ class SonOfGridEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(self._system_call_error_warn_msg(system_command))
+                    raise subprocess.CalledProcessError(retval, self._system_call_error_warn_msg(system_command))
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -324,9 +324,9 @@ class SonOfGridEngine(EngineBase):
             try:
                 out, err, retval = self.system_call(system_command)
                 if retval != 0:
-                    raise subprocess.CalledProcessError(
-                        retval, system_command, self._system_call_error_warn_msg(system_command)
-                    )
+                    logging.warning(self._system_call_error_warn_msg(system_command))
+                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -416,10 +416,7 @@ class SonOfGridEngine(EngineBase):
         name = task.task_name()
         name = escape_name(name)
         task_name = (name, task_id)
-        try:
-            queue_state = self.queue_state()
-        except subprocess.CalledProcessError:
-            return STATE_RUNNABLE
+        queue_state = self.queue_state()
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -256,10 +256,6 @@ class SonOfGridEngine(EngineBase):
         while True:
             try:
                 out, err, retval = self.system_call(qsub_call, command)
-                if retval != 0:
-                    logging.warning(self._system_call_error_warn_msg(qsub_call))
-                    time.sleep(gs.WAIT_PERIOD_QSTAT_PARSING)
-                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(qsub_call))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -79,6 +79,11 @@ class SonOfGridEngine(EngineBase):
             return f"SSH command timeout: {command!s}"
         return f"Command timeout: {command!s}"
 
+    def _system_call_error_warn_msg(self, command: Any) -> str:
+        if self.gateway:
+            return f"SSH command error: {command!s}"
+        return f"Command error: {command!s}"
+
     def system_call(self, command, send_to_stdin=None):
         """
         :param list[str] command: qsub command
@@ -251,6 +256,10 @@ class SonOfGridEngine(EngineBase):
         while True:
             try:
                 out, err, retval = self.system_call(qsub_call, command)
+                if retval != 0:
+                    logging.warning(self._system_call_error_warn_msg(qsub_call))
+                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(qsub_call))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)
@@ -318,6 +327,10 @@ class SonOfGridEngine(EngineBase):
         while True:
             try:
                 out, err, retval = self.system_call(system_command)
+                if retval != 0:
+                    logging.warning(self._system_call_error_warn_msg(system_command))
+                    time.sleep(gs.WAIT_PERIOD_BETWEEN_CHECKS)
+                    continue
             except subprocess.TimeoutExpired:
                 logging.warning(self._system_call_timeout_warn_msg(system_command))
                 time.sleep(gs.WAIT_PERIOD_SSH_TIMEOUT)

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -15,7 +15,7 @@ from collections import defaultdict, namedtuple
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
+from sisyphus.global_settings import STATE_RUNNABLE, STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "sge"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])
@@ -419,7 +419,7 @@ class SonOfGridEngine(EngineBase):
         try:
             queue_state = self.queue_state()
         except subprocess.CalledProcessError:
-            return STATE_QUEUE_ERROR
+            return STATE_RUNNABLE
         qs = queue_state[task_name]
 
         # task name should be uniq

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -15,7 +15,7 @@ from collections import defaultdict, namedtuple
 
 import sisyphus.global_settings as gs
 from sisyphus.engine import EngineBase
-from sisyphus.global_settings import STATE_RUNNABLE, STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
+from sisyphus.global_settings import STATE_RUNNING, STATE_UNKNOWN, STATE_QUEUE, STATE_QUEUE_ERROR
 
 ENGINE_NAME = "sge"
 TaskInfo = namedtuple("TaskInfo", ["job_id", "task_id", "state"])


### PR DESCRIPTION
Fix #175.

Whenever the return value of the queue scan command is different from zero, the job states are eventually set as `UNKNOWN`. Whenever some job is set as `UNKNOWN` and there's no log file attached, the job will be automatically considered as `RUNNABLE` and queued.

This is a very dangerous process because there's usually a job already queued "naturally", that is, queued because the queue scan job finished gracefully, found nothing, and set the job state as `UNKNOWN`, thus queuing the job normally.

This wrong process can happen many times, until the first job scheduled eventually enters `RUNNING` state, and thus a log file is generated, preventing any further same job schedulings.

This PR fixes such wrong behavior by making the queue scan wait some seconds before rescheduling it again after a failure in the scan, and not directly setting the job state as `UNKNOWN`.