### PR TITLE
allow keeping input folder during job cleanup

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -133,7 +133,7 @@ JOB_CLEANER_WORKER = 5
 #: If the job internal work directory should be kept or deleted during clean up
 JOB_CLEANUP_KEEP_WORK = False
 #: If the job internal input directory with symlinks to input jobs should be kept or deleted during clean up
-JOB_CLEANUP_KEEP_INPUT = False
+JOB_CLEANUP_KEEP_INPUT = True
 #: Default value for job used by tk.cleaner to determine if a job should be removed or not
 JOB_DEFAULT_KEEP_VALUE = 50
 #: How many threads should update the graph in parallel, useful if the filesystem has a high latency

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -130,8 +130,10 @@ JOB_AUTO_CLEANUP = True
 JOB_CLEANER_INTERVAL = 60
 #: How many threads should be cleaning in parallel
 JOB_CLEANER_WORKER = 5
-#: If the job internal work directory should be keeped re deleted during clean up
+#: If the job internal work directory should be kept or deleted during clean up
 JOB_CLEANUP_KEEP_WORK = False
+#: If the job internal input directory with symlinks to input jobs should be kept or deleted during clean up
+JOB_CLEANUP_KEEP_INPUT = False
 #: Default value for job used by tk.cleaner to determine if a job should be removed or not
 JOB_DEFAULT_KEEP_VALUE = 50
 #: How many threads should update the graph in parallel, useful if the filesystem has a high latency

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -516,13 +516,10 @@ class Job(metaclass=JobSingleton):
                 try:
                     if not gs.JOB_CLEANUP_KEEP_WORK:
                         shutil.rmtree(os.path.abspath(self._sis_path(gs.JOB_WORK_DIR)))
-                    if not gs.JOB_CLEANUP_KEEP_INPUT:
-                        shutil.rmtree(os.path.abspath(self._sis_path(gs.JOB_INPUT)))
-                    files = [
-                        i
-                        for i in os.listdir(self._sis_path())
-                        if i not in (gs.JOB_OUTPUT, gs.JOB_INFO, gs.JOB_WORK_DIR, gs.JOB_INPUT)
-                    ]
+                    files_keep = [gs.JOB_OUTPUT, gs.JOB_INFO, gs.JOB_WORK_DIR]
+                    if gs.JOB_CLEANUP_KEEP_INPUT:
+                        files_keep.append(gs.JOB_INPUT)
+                    files = [i for i in os.listdir(self._sis_path()) if i not in files_keep]
                     subprocess.check_call(
                         ["tar", "-czf", gs.JOB_FINISHED_ARCHIVE] + files, cwd=os.path.abspath(self._sis_path())
                     )

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -516,10 +516,12 @@ class Job(metaclass=JobSingleton):
                 try:
                     if not gs.JOB_CLEANUP_KEEP_WORK:
                         shutil.rmtree(os.path.abspath(self._sis_path(gs.JOB_WORK_DIR)))
+                    if not gs.JOB_CLEANUP_KEEP_INPUT:
+                        shutil.rmtree(os.path.abspath(self._sis_path(gs.JOB_INPUT)))
                     files = [
                         i
                         for i in os.listdir(self._sis_path())
-                        if i not in (gs.JOB_OUTPUT, gs.JOB_INFO, gs.JOB_WORK_DIR)
+                        if i not in (gs.JOB_OUTPUT, gs.JOB_INFO, gs.JOB_WORK_DIR, gs.JOB_INPUT)
                     ]
                     subprocess.check_call(
                         ["tar", "-czf", gs.JOB_FINISHED_ARCHIVE] + files, cwd=os.path.abspath(self._sis_path())


### PR DESCRIPTION
When sisyphus cleans up a job folder, the input folder is deleted. This can be impractical if you want to find some job's dependencies because instead of just going through the input folders, you need to open each `finished.tar.gz` file and check for input jobs in the `info` file. I therefore propose to add the config option `JOB_CLEANUP_KEEP_INPUT`. It set to True, the input folder will remain even after cleaning.

Edit: As suggested in the PR, we set `JOB_CLEANUP_KEEP_INPUT = True` as the default setting. This changes the default behavior, but is not expected to hurt anyone.