### PR TITLE
Add Logging filtering and Alias printing to Cleaning

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -161,6 +161,9 @@ JOB_CLEANUP_KEEP_WORK = False
 JOB_CLEANUP_KEEP_INPUT = True
 #: Default value for job used by tk.cleaner to determine if a job should be removed or not
 JOB_DEFAULT_KEEP_VALUE = 50
+#:
+CLEANER_PRINT_ALIAS = True
+
 #: How many threads should update the graph in parallel, useful if the filesystem has a high latency
 GRAPH_WORKER = 16
 


### PR DESCRIPTION
When using the sis cleaner I often run into two problems:
1. I clean >5000 jobs, which causes "List affected directories" to be unreadable
2. The list only gives the hash, which is kind of useless when determining if the job is really to be cleaned (since I use subgraphs I want to ensure that the main graph is complete and I dont accidentality clean wrong things)

This PR proposed solutions to both problems. 
The first is introducing the option to give substrings to the clean methods, such that only jobs which fit the substring (e.g. ReturnnTraining or AdvancedTree) will be printed when listing.
The second is reading the info file of the cleaned jobs and trying to get the alias during creation. This of course is purely heuristic and there might be a cleaner solution, but I could not find one, since the alias itself does not exist if the job is not in the graph. 

If there are better solutions to one of the problems feel free to suggest, so that I can update them. 
Also I added some typing/doc.