### PR TITLE
cleanup redundant create_aliases call

### DIFF
--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -92,9 +92,6 @@ def manager(args):
     manager = None
 
     try:
-        if args.run:
-            create_aliases(sis_graph.jobs())
-
         # The actual work loop
         if args.http_port is not None:
             logging.debug("Start http server")


### PR DESCRIPTION
When `--run` is used, it will anyway still call create_aliases later, just in the same way as without the `--run` option.