### PR TITLE
Add timer to print update

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -245,6 +245,8 @@ PRINT_ERROR_TASKS = 1
 PRINT_ERROR_LINES = 40
 #: Print message for held jobs
 PRINT_HOLD = True
+#: Print State Overview even though no updates happened
+PRINT_STALE_STATE_OVERVIEW_PERIOD = None
 
 #: Log for finished outputs.
 FINISHED_LOG = "log/finished.log"

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -579,6 +579,7 @@ class Manager(threading.Thread):
             return
 
         last_state_overview = self.state_overview
+        time_last_update = time.time()
         while self.continue_manager_loop():
             finished_results_cache.write_to_file()
             # Don't to anything while the manager is paused
@@ -602,11 +603,16 @@ class Manager(threading.Thread):
 
             if self.auto_print_stat_overview:
                 self.update_state_overview()
-                if last_state_overview != self.state_overview:
+                if last_state_overview != self.state_overview or (
+                    gs.PRINT_STALE_STATE_OVERVIEW_PERIOD is not None
+                    and time.time() - time_last_update > gs.PRINT_STALE_STATE_OVERVIEW_PERIOD
+                ):
                     if self.ui:
+                        time_last_update = time.time()
                         self.ui.update_job_view(self.get_job_states())
                         self.ui.update_state_overview(" ".join(sorted(self.state_overview)))
                     else:
+                        time_last_update = time.time()
                         self.print_state_overview()
                     last_state_overview = self.state_overview
 


### PR DESCRIPTION
When running experiments in subgraphs I often encounter that only 3-4 trainings and nothing else is running. When only doing recognitions on e.g. the last checkpoint this causes the manager to not print an update for a long time. Since the Training job info also includes the current epoch, its desirable for me to print an update every x seconds.  
Thus I propose this flag that if set does this.