### PR TITLE
Slurm, fix ntasks per node to one

### DIFF
--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -176,6 +176,11 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         if rqmt.get("multi_node_slots", 1) > 1:
             out.append("--ntasks=%s" % rqmt["multi_node_slots"])
             out.append("--nodes=%s" % rqmt["multi_node_slots"])
+        else:
+            # With --cpus-per-task=1, it's sometimes possible that we end up with SLURM_NTASKS=2.
+            # This here prevents this.
+            # https://github.com/rwth-i6/sisyphus/issues/229
+            out.append("--ntasks-per-node=1")
 
         sbatch_args = rqmt.get("sbatch_args", [])
         if isinstance(sbatch_args, str):


### PR DESCRIPTION
Fix #229.

(Makes PR #230 obsolete.)

(This seems to be needed since we use an additional explicit `srun` via PR #212.)