### PR TITLE
Slurm, fix when running sis worker outside Slurm env

### DIFF
--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -426,7 +426,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         engine_logpath = (
             os.path.dirname(logpath)
             + "/engine/"
-            + os.getenv("SLURM_JOB_NAME")
+            + os.getenv("SLURM_JOB_NAME", self.process_task_name(task.task_name()))
             + "."
             + job_id
             + "."


### PR DESCRIPTION
You might want to run `sis worker ...` directly to debug something.