### PR TITLE
CI black: update Python

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.14
+        python-version: 3.13
         cache: 'pip'
         cache-dependency-path: '.github/workflows/black.yml'
     - run: pip install black==22.3.0

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.14
         cache: 'pip'
         cache-dependency-path: '.github/workflows/black.yml'
     - run: pip install black==22.3.0


### PR DESCRIPTION
Python 3.7 not available anymore in CI.