### PR TITLE
Implement is_set for AbstractPath

### DIFF
--- a/sisyphus/job_path.py
+++ b/sisyphus/job_path.py
@@ -161,6 +161,9 @@ class AbstractPath(DelayedBase):
                     logging.warning("Job marked as finished but requested output is not available: %s" % self)
             return job_path_available
 
+    def is_set(self):
+        return self.available()
+
     # TODO Move this to toolkit cleanup together with job method
     def get_needed_jobs(self, visited):
         """Return all jobs leading to this path"""


### PR DESCRIPTION
`AbstractPath` inherits from `DelayedBase`, but the implementation of `DelayedBase.is_set` https://github.com/rwth-i6/sisyphus/blob/a7a01653301f3098f7201eac7fbef4073f42b610/sisyphus/delayed_ops.py#L19-L20 is incompatible with `AbstractPath`, because it does not have `a` and `b`.
Fortunately `AbstractPath` implements a method `available` which we can use instead.