### PR TITLE
CI test: use ubuntu-latest, Python 3.8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 ignore = F401, C901, F403, F405, W503
-extend-ignore = E203  # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
+extend-ignore = E203
 max-line-length = 120
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
+          - 3.8
 
     steps:
     - uses: actions/checkout@v2

--- a/sisyphus/filesystem.py
+++ b/sisyphus/filesystem.py
@@ -2,7 +2,6 @@
 
 import os
 import time
-import collections
 import types
 from sisyphus.tools import cache_result
 
@@ -10,10 +9,8 @@ from fuse import FUSE, Operations
 from sisyphus import toolkit
 from sisyphus.block import all_root_blocks
 
-Symlink = collections.namedtuple("Symlink", ["target"])
 
-
-class FilesystemObject(object):
+class FilesystemObject:
     pass
 
 

--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -62,7 +62,7 @@ class OutputTarget:
             return self.required_full_list
 
     def __eq__(self, other):
-        return type(self) == type(other) and self.__dict__ == other.__dict__
+        return type(self) is type(other) and self.__dict__ == other.__dict__
 
     def __hash__(self):
         return sisyphus.hash.int_hash(self)

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -768,7 +768,7 @@ class Job(metaclass=JobSingleton):
         return str(self)
 
     def __eq__(self, other):
-        if type(other) != type(self):
+        if type(other) is not type(self):
             return False
         else:
             # TODO Check how uninitialized object should behave here

--- a/sisyphus/job_path.py
+++ b/sisyphus/job_path.py
@@ -228,7 +228,7 @@ class AbstractPath(DelayedBase):
         return s < o
 
     def __eq__(self, other):
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
 
         # TODO Check how uninitialized object should behave here

--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -675,7 +675,7 @@ def compare_graph(obj1, obj2, traceback=None, visited=None):
 
     if skip:
         pass
-    elif type(obj1) != type(obj2):
+    elif type(obj1) is not type(obj2):
         yield traceback + [(type(obj1), type(obj2))]
     elif isinstance(obj1, Job):
         if obj1._sis_id() != obj2._sis_id():

--- a/sisyphus/visualize.py
+++ b/sisyphus/visualize.py
@@ -58,7 +58,7 @@ def visualize_block(block, engine, vis_url_prefix):
 
     for i in inputs:
         creator = input_to_node[i] if i in input_to_node else ""
-        users = sorted(t[1] for t in filter(lambda l: l[0] == i, links))
+        users = sorted(t[1] for t in filter(lambda link: link[0] == i, links))
         hash = sis_hash((creator, users))
         merge_inputs_mapping[i] = hash
         if hash not in merged_labels:


### PR DESCRIPTION
Currently CI fails with this message:

> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101
>
> GitHub Actions has encountered an internal error when running your job.

I assume this would be fixed by this update.

Somewhat related is #195.

Fixes #246.