### PR TITLE
create_aliases, duplicates warning, print stack trace

### DIFF
--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -351,7 +351,7 @@ class SISGraph(object):
     def job_by_id(self, sis_id):
         return self.id_to_job_dict().get(sis_id)
 
-    def jobs(self):
+    def jobs(self) -> List[Job]:
         """
         :return ([Job, ...]): List with all jobs in grpah
         """

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -6,6 +6,7 @@ Module to contain all job related code
 
 """
 
+from __future__ import annotations
 import copy
 import gzip
 import inspect
@@ -18,7 +19,7 @@ import subprocess
 import sys
 import time
 import traceback
-from typing import List, Iterator, Type, TypeVar
+from typing import Optional, Any, List, Iterator, Type, TypeVar, Set, Dict
 
 from sisyphus import block, tools
 from sisyphus.task import Task
@@ -202,7 +203,7 @@ class Job(metaclass=JobSingleton):
                     % (str(arg)[3:], key, self.__class__)
                 )
 
-        self._sis_aliases = None
+        self._sis_aliases: Optional[Set[str]] = None
         self._sis_alias_prefixes = set()
         self._sis_vis_name = None
         self._sis_output_dirs = set()
@@ -554,11 +555,10 @@ class Job(metaclass=JobSingleton):
         return self._sis_id_cache.encode()
 
     @classmethod
-    def _sis_hash_static(cls, parsed_args):
+    def _sis_hash_static(cls, parsed_args: Dict[str, Any]) -> str:
         """
-        :param dict[str] parsed_args:
+        :param parsed_args:
         :return: hash
-        :rtype: str
         """
         h = cls.hash(parsed_args)
         assert isinstance(h, str), "hash return value must be str"
@@ -1009,7 +1009,7 @@ class Job(metaclass=JobSingleton):
         """Returns a unique string to identify this job"""
         return self._sis_id()
 
-    def get_aliases(self):
+    def get_aliases(self) -> Optional[Set[str]]:
         return self._sis_aliases
 
     def get_one_alias(self):
@@ -1021,7 +1021,7 @@ class Job(metaclass=JobSingleton):
                 return None
         return None
 
-    def add_alias(self, alias):
+    def add_alias(self, alias: str):
         if self._sis_aliases is None:
             self._sis_aliases = set()
         self._sis_aliases.add(alias)

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -681,11 +681,11 @@ def create_aliases(jobs: Collection[Job]):
                     logging.warning("First use: %s" % aliases[alias].job_id())
                     if aliases[alias]._sis_stacktrace:
                         for line in traceback.format_list(aliases[alias]._sis_stacktrace[0]):
-                            logging.info(line)
+                            logging.info("%s", line.rstrip())
                     logging.warning("Additional use: %s" % job.job_id())
                     if job._sis_stacktrace:
                         for line in traceback.format_list(job._sis_stacktrace[0]):
-                            logging.info(line)
+                            logging.info("%s", line.rstrip())
                 else:
                     aliases[alias] = job
 

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -681,11 +681,11 @@ def create_aliases(jobs: Collection[Job]):
                     logging.warning("First use: %s", aliases[alias].job_id())
                     if aliases[alias]._sis_stacktrace:
                         for line in traceback.format_list(aliases[alias]._sis_stacktrace[0]):
-                            logging.info("%s", line.rstrip())
+                            logging.info("%s", line.splitlines()[0])
                     logging.warning("Additional use: %s" % job.job_id())
                     if job._sis_stacktrace:
                         for line in traceback.format_list(job._sis_stacktrace[0]):
-                            logging.info("%s", line.rstrip())
+                            logging.info("%s", line.splitlines()[0])
                 else:
                     aliases[alias] = job
 

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -1,3 +1,8 @@
+"""
+Sisyphus manager
+"""
+
+from __future__ import annotations
 import asyncio
 import atexit
 import logging
@@ -6,6 +11,7 @@ import sys
 import threading
 import time
 import warnings
+from typing import TYPE_CHECKING, Dict, Collection
 
 from multiprocessing.pool import ThreadPool
 
@@ -14,6 +20,9 @@ from sisyphus.loader import config_manager
 from sisyphus.block import Block
 from sisyphus.tools import finished_results_cache
 import sisyphus.global_settings as gs
+
+if TYPE_CHECKING:
+    from sisyphus.job import Job
 
 
 class JobCleaner(threading.Thread):
@@ -653,7 +662,7 @@ class Manager(threading.Thread):
         self.check_output(write_output=self.link_outputs, update_all_outputs=True, force_update=True)
 
 
-def create_aliases(jobs):
+def create_aliases(jobs: Collection[Job]):
     # first scan jobs for aliases
     aliases = {}
     alias_dirs = set()

--- a/sisyphus/manager.py
+++ b/sisyphus/manager.py
@@ -677,8 +677,8 @@ def create_aliases(jobs: Collection[Job]):
             for alias in orig_aliases:
                 alias = os.path.join(prefix, alias)
                 if alias in aliases:
-                    logging.warning("Alias %s is used multiple times:" % alias)
-                    logging.warning("First use: %s" % aliases[alias].job_id())
+                    logging.warning("Alias %s is used multiple times:", alias)
+                    logging.warning("First use: %s", aliases[alias].job_id())
                     if aliases[alias]._sis_stacktrace:
                         for line in traceback.format_list(aliases[alias]._sis_stacktrace[0]):
                             logging.info("%s", line.rstrip())


### PR DESCRIPTION
When you get the warning `Alias ... is used multiple times`, it will now also print the stacktrace of both jobs (if storing the stacktrace of each job was enabled, which it is not by default).

Along the way, I added some typing info.