### PR TITLE
Fix job IDs in SLURM log symlink not matching up

### DIFF
--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -238,7 +238,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         :param int step_size:
         """
         name = self.process_task_name(name)
-        out_log_file = f"{logpath}/%x.%j.%a"
+        out_log_file = f"{logpath}/%x.%A.%a"
         if rqmt.get("multi_node_slots", 1) > 1:
             out_log_file += ".%t"
         sbatch_call = ["sbatch", "-J", name, "--mail-type=None"]
@@ -420,13 +420,12 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         if os.path.isfile(logpath):
             os.unlink(logpath)
 
-        job_id = next(filter(None, (os.getenv(name, None) for name in ["SLURM_JOB_ID", "SLURM_JOBID"])), "0")
         engine_logpath = (
             os.path.dirname(logpath)
             + "/engine/"
             + os.getenv("SLURM_JOB_NAME", self.process_task_name(task.task_name()))
             + "."
-            + job_id
+            + os.getenv("SLURM_ARRAY_JOB_ID", "0")
             + "."
             + os.getenv("SLURM_ARRAY_TASK_ID", "1")
         )

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -238,7 +238,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         :param int step_size:
         """
         name = self.process_task_name(name)
-        out_log_file = f"{logpath}/%x.%A.%a"
+        out_log_file = f"{logpath}/%x.%j.%a"
         if rqmt.get("multi_node_slots", 1) > 1:
             out_log_file += ".%t"
         sbatch_call = ["sbatch", "-J", name, "--mail-type=None"]

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -420,9 +420,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         if os.path.isfile(logpath):
             os.unlink(logpath)
 
-        job_id = next(
-            filter(None, (os.getenv(name, None) for name in ["SLURM_JOB_ID", "SLURM_JOBID", "SLURM_ARRAY_JOB_ID"])), "0"
-        )
+        job_id = next(filter(None, (os.getenv(name, None) for name in ["SLURM_JOB_ID", "SLURM_JOBID"])), "0")
         engine_logpath = (
             os.path.dirname(logpath)
             + "/engine/"


### PR DESCRIPTION
It turns out, %A refers to different things in `sbatch` and in the wrapped `srun`, leading to broken log symlinks in the job folder :( 

%j seems to be consistent: https://slurm.schedmd.com/sbatch.html, I also confirmed locally.

Current behavior (pre-fix):
```
❯ ls work/config/create_corpora/CreateCsvFromAvroJob.Z8lxU0d8s4Dt/engine
config.create_corpora.CreateCsvFromAvroJob.Z8lxU0d8s4Dt.run.8344989.1
```

```
❯ ll work/config/create_corpora/CreateCsvFromAvroJob.Z8lxU0d8s4Dt/log.run.1
lrwxrwxrwx 1 mgunz domain_users 76 Mar 25 07:54 work/config/create_corpora/CreateCsvFromAvroJob.Z8lxU0d8s4Dt/log.run.1 -> engine/config.create_corpora.CreateCsvFromAvroJob.Z8lxU0d8s4Dt.run.8345118.1
```

```
❯ scontrol show jobid 8345118
JobId=8345118 ArrayJobId=8344989 ArrayTaskId=1 JobName=config.create_corpora.CreateCsvFromAvroJob.Z8lxU0d8s4Dt.run
   [...]
   StdOut=/nas/data/speech/untranscribed/EVDS/setups/2025-03-24_mgunz_corpus/work/config/create_corpora/CreateCsvFromAvroJob.Z8lxU0d8s4Dt/engine/config.create_corpora.CreateCsvFromAvroJob.Z8lxU0d8s4Dt.run.8344989.1.batch
```

With the fix the job directory looks as usual/intended with the log files from the job main directory hardlinked to the log files in the engine directory. We also have .batch log files in the engine directory (since that PR), which contain the logs of the srun invocation when the job has been scheduled, but not any logs of the sisyphus job itself.