### PR TITLE
Add gs.on_job_finished callback

### DIFF
--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -7,7 +7,7 @@ These settings can be overwritten via a ``settings.py`` file in the current dire
 import logging
 import sys
 from typing import Dict
-
+from future import __annotations__
 import sisyphus.hash
 from sisyphus.global_constants import *
 from typing import TYPE_CHECKING

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -85,6 +85,19 @@ def on_job_failure(job):
     pass
 
 
+def on_job_finished(job):
+    """
+    Job finished hook.
+
+    Can be used to update permissions on job outputs after completion.
+
+    The callback needs to be stateless and indempotent, as it can be called multiple
+    times on the same job, especially if the job is from another user and sisyphus
+    can't add the job finished marker.
+    """
+    pass
+
+
 def update_engine_rqmt(last_rqmt: Dict, last_usage: Dict):
     """Update requirements after a job got interrupted, double limits if needed
 

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -10,6 +10,10 @@ from typing import Dict
 
 import sisyphus.hash
 from sisyphus.global_constants import *
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sisyphus import Job
 
 
 def engine():
@@ -60,7 +64,7 @@ def worker_wrapper(job, task_name, call):
     return call
 
 
-def on_job_failure(job):
+def on_job_failure(job: Job):
     """
     Job failure hook.
 
@@ -85,7 +89,7 @@ def on_job_failure(job):
     pass
 
 
-def on_job_finished(job):
+def on_job_finished(job: Job):
     """
     Job finished hook.
 

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -3,11 +3,11 @@ These settings can be overwritten via a ``settings.py`` file in the current dire
 """
 
 # Author: Jan-Thorsten Peter <peter@cs.rwth-aachen.de>
-
+from __future__ import annotations
 import logging
 import sys
 from typing import Dict
-from future import __annotations__
+
 import sisyphus.hash
 from sisyphus.global_constants import *
 from typing import TYPE_CHECKING

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -498,6 +498,7 @@ class Job(metaclass=JobSingleton):
                     # finished marker
                     pass
                 self._sis_link_to_team_share_dir()
+                gs.on_job_finished(self)
                 return True
             else:
                 # Job is not even setup => can not be finished yet


### PR DESCRIPTION
I need this to update permissions on certain output files of some jobs. This seems like a good generic solution that can be used in other situations as well, just like `gs.on_job_failure`