### PR TITLE
CI fix caching for setup-python, update to v5

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: 3.13
         cache: 'pip'
-        cache-dependency-path: '.github/workflows/black.yml'        
+        cache-dependency-path: '.github/workflows/black.yml'
     - run: pip install black==22.3.0
     - run: black --diff .
     - run: black --check .

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -18,8 +18,6 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.13
-        cache: 'pip'
-        cache-dependency-path: '.github/workflows/black.yml'
     - run: pip install black==22.3.0
     - run: black --diff .
     - run: black --check .

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -15,9 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.13
+        cache: 'pip'
+        cache-dependency-path: '.github/workflows/black.yml'        
     - run: pip install black==22.3.0
     - run: black --diff .
     - run: black --check .


### PR DESCRIPTION
Currently, the CI on black always fails like this:
```
Run actions/setup-python@v2
  with:
    python-version: 3.13
    cache: pip
    cache-dependency-path: .github/workflows/black.yml
    token: ***
Successfully setup CPython (3.13.3)
/opt/hostedtoolcache/Python/3.13.3/x64/bin/pip cache dir
/home/runner/.cache/pip
Error: Cache service responded with 422
```

Related:
https://github.com/lukka/run-vcpkg/issues/243
https://github.com/microsoft/vcpkg/issues/45073
https://github.com/actions/cache/issues/1593