### PR TITLE
fix OutputTarget __hash__

### DIFF
--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -62,10 +62,14 @@ class OutputTarget:
             return self.required_full_list
 
     def __eq__(self, other):
-        return type(self) is type(other) and self.__dict__ == other.__dict__
+        return (
+            type(self) is type(other)
+            and self.name == other.name
+            and self.required_full_list == other.required_full_list
+        )
 
     def __hash__(self):
-        return sisyphus.hash.int_hash(self)
+        return hash((type(self), self.name, self.required_full_list))
 
 
 class OutputPath(OutputTarget):

--- a/sisyphus/graph.py
+++ b/sisyphus/graph.py
@@ -69,7 +69,7 @@ class OutputTarget:
         )
 
     def __hash__(self):
-        return hash((type(self), self.name, self.required_full_list))
+        return hash((type(self), self.name, tuple(self.required_full_list)))
 
 
 class OutputPath(OutputTarget):


### PR DESCRIPTION
Fix #256.

`OutputTarget.update_requirements` will update the internal state of the object, and that will change the output of `OutputTarget.__hash__`.

Any use of the hash (e.g. in `set`/`dict`), such as the use introduced in #255 to speed up `SISGraph.remove_from_active_targets`, is likely broken, when the state of the object changes. And this is the case in `Manager.check_output`, which calls `OutputTarget.update_requirements`.

This fixes `OutputTarget.__hash__` in a way that it does not change when the requirements change.