### PR TITLE
Handle bound methods in tools.extract_paths

### DIFF
--- a/sisyphus/tools.py
+++ b/sisyphus/tools.py
@@ -15,6 +15,7 @@ import logging
 import subprocess
 import linecache
 from typing import Set, Any
+from inspect import ismethod
 
 try:
     import tracemalloc
@@ -99,6 +100,8 @@ def extract_paths(args: Any) -> Set:
             for k, v in obj.items():
                 if not isinstance(k, str) or not k.startswith("_sis_"):
                     queue.append(v)
+        elif ismethod(obj) and hasattr(obj, "__self__") and obj.__self__ is not None:
+            queue.append(obj.__self__)
         else:
             queue.append(get_object_state(obj))
     return out


### PR DESCRIPTION
With this change paths from the instance a bound method is bound to are also extracted when calling `tools.extract_paths`.

Specifically, I needed this as my custom worker_wrapper depends on a job that builds the venv that is used in the worker_wrapper.

I'm unsure whether it's better to implement this here or in `get_object_state`. In `get_object_state` this might influence the hashes of existing setups (but if I see it correctly bound methods are not handled properly there at the moment).