### PR TITLE
DelayedOps: dict.__getitem__ with delayed key

### DIFF
--- a/sisyphus/delayed_ops.py
+++ b/sisyphus/delayed_ops.py
@@ -139,7 +139,7 @@ class DelayedRound(DelayedBase):
 
 class DelayedGetItem(DelayedBase):
     def get(self):
-        return try_get(self.a)[self.b]
+        return try_get(self.a)[try_get(self.b)]
 
 
 class Delayed(DelayedBase):

--- a/sisyphus/tools.py
+++ b/sisyphus/tools.py
@@ -119,10 +119,11 @@ def try_get(v):
     Useful to convert a sisyphus path or variable into the stored object
     """
 
-    try:
+    from sisyphus.delayed_ops import DelayedBase  # here to avoid circular import
+
+    if isinstance(v, DelayedBase):
         return v.get()
-    except AttributeError:
-        return v
+    return v
 
 
 class execute_in_dir(object):


### PR DESCRIPTION
To do something like:
```
models = {1: model_eopch1, 2: model_epoch2, ...}

best_epoch = SelectBestEpochJob(all_scores).out  # tk.Variable

best_model = tk.Delayed(models)[best_epoch]
```

Or just any situation where a dict key depends on a job output. Actually, should also work for list indexing.
`DelayedSlice` already supports both delayed iterable as well as delayed range start/end/step, so this is just the analogous thing for "simple" access.
