### PR TITLE
`DelayedGetItem`: fix case where first element is dictionary

### DIFF
--- a/sisyphus/delayed_ops.py
+++ b/sisyphus/delayed_ops.py
@@ -139,7 +139,8 @@ class DelayedRound(DelayedBase):
 
 class DelayedGetItem(DelayedBase):
     def get(self):
-        return try_get(self.a)[try_get(self.b)]
+        wrapped_dict = self.a if isinstance(self.a, dict) else try_get(self.a)
+        return wrapped_dict[try_get(self.b)]
 
 
 class Delayed(DelayedBase):


### PR DESCRIPTION
In https://github.com/rwth-i6/sisyphus/pull/273, a delayed dictionary get operation is introduced, which is exactly what I need for my use case. However, the current implementation does not work when the first element to `DelayedDictGet` is already a dictionary due to the fact that both methods `DelayedBase.get()` and `dict.get(key)` are called the same (`get`), so an `AttributeError` does NOT happen when running `try_get(self.a)` (since `dict.get` exists) but a `TypeError: Expected 1 parameter, 0 found`.

The check proposed in this PR prevents the manager from running `try_get(a)` when `isinstance(a, dict)` (which would internally run `dict.get()` without any key, which is wrong) to be run in the first place, and works on the dictionary directly if it's already a dictionary.

@patrick-wilken did you envision any other implementation when the first parameter was already a dictionary?