### PR TITLE
Hash bound methods

### DIFF
--- a/sisyphus/hash.py
+++ b/sisyphus/hash.py
@@ -2,7 +2,7 @@ from typing import Tuple
 import enum
 import hashlib
 import pathlib
-from inspect import isclass, isfunction, ismemberdescriptor, ismethod
+from inspect import isclass, isfunction, ismemberdescriptor
 
 
 def md5(obj):
@@ -74,8 +74,6 @@ def get_object_state(obj):
                 raise TypeError(f"derived type {obj!r} {type(obj)!r} not handled yet")
     if isfunction(obj) or isclass(obj):
         return obj.__module__, obj.__qualname__
-    if ismethod(obj):
-        return get_object_state(obj.__self__), get_object_state(obj.__func__)
 
     if isinstance(obj, pathlib.PurePath):
         # pathlib paths have a somewhat technical internal state
@@ -201,7 +199,8 @@ def _getmembers(obj):
         if getattr(cls, "__dict__", None):
             cls_dict.update(cls.__dict__)
     for key in dir(obj):
-        if key.startswith("__"):
+        # for bound methods, need to keep __self__ and __func__.
+        if key.startswith("__") and key not in ["__self__", "__func__"]:
             continue
         if key in res:
             continue

--- a/tests/hash_unittest.py
+++ b/tests/hash_unittest.py
@@ -73,7 +73,21 @@ class HashTest(unittest.TestCase):
     def test_bound_method(self):
         first_obj = MyFoo("First")
         second_obj = MyFoo("Second")
-        self.assertNotEqual(sis_hash_helper(first_obj.get_data), sis_hash_helper(second_obj.get_data))
+        func_hash = sis_hash_helper(MyFoo.get_data)
+        bound_to_first_obj_hash = sis_hash_helper(first_obj.get_data)
+        bound_to_second_obj_hash = sis_hash_helper(second_obj.get_data)
+
+        self.assertEqual(func_hash, b"(function, (tuple, (str, 'tests.hash_unittest'), (str, 'MyFoo.get_data')))")
+        self.assertEqual(
+            bound_to_first_obj_hash,
+            (
+                b"(method, (dict, "
+                b"(tuple, (str, '__func__'), " + func_hash + b"), "
+                b"(tuple, (str, '__self__'), (MyFoo, (dict, (tuple, (str, 'some_data'), (str, 'First')))))"
+                b"))"
+            ),
+        )
+        self.assertNotEqual(bound_to_first_obj_hash, bound_to_second_obj_hash)
 
     def test_pathlib_Path(self):
         from pathlib import Path


### PR DESCRIPTION
Hashing of bound methods wasn't supported before:

Before: `sis_hash_helper(MyObject().bound_method) = b'(method, (dict))'`.
All bound methods had the same hash.

Now it returns a proper hash, in particular binding the same method to different objects also gives a different hash.