### PR TITLE
Slurm engine: higher timeout for commands

### DIFF
--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -107,7 +107,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
         if send_to_stdin:
             send_to_stdin = send_to_stdin.encode()
 
-        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=30)
+        p = subprocess.run(system_command, input=send_to_stdin, capture_output=True, timeout=200)
 
         def fix_output(o):
             """


### PR DESCRIPTION
If the timeout is too low, you might risk to submit jobs multiple times. In case of RWTH HPC, the Slurm config sets MessageTimeout=100, i.e. 100 seconds. So I had the case where I got the "Command timeout" warning but it actually submitted the jobs.

Note, I was thinking about some alternatives to this change:

* We could also make it configurable instead. (But then should we still leave the default to 30, or change the default maybe anyway?)
* We could somehow read the MessageTimeout setting and make sure our timeout is at least as high. But I'm not sure how simple this is. Can we just read `/etc/slurm/slurm.conf` and parse it from there?

But I decided this is simpler for now, and the extra complexity is maybe not really needed. Simplicity should win.

Closes #281. (Even though this is not a perfect solution for it yet...)
