### PR TITLE
Reset retry counter when there is progress

### DIFF
--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -187,7 +187,9 @@ class EngineBase:
             submit_info = rqmt.copy()
             submit_info["engine_info"] = engine_info
             submit_info["engine_name"] = engine_name
-            submit_info["completed_fraction"] = task._job.completed_fraction()
+            completed_fraction = task._job.completed_fraction()
+            assert completed_fraction is None or 0 <= completed_fraction <= 1, f"{task._job} {completed_fraction=!r}"
+            submit_info["completed_fraction"] = completed_fraction
             with open(submit_log, "a") as submit_file:
                 submit_file.write("%s\n" % str((task_ids, submit_info)))
 

--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -187,6 +187,7 @@ class EngineBase:
             submit_info = rqmt.copy()
             submit_info["engine_info"] = engine_info
             submit_info["engine_name"] = engine_name
+            submit_info["completed_fraction"] = task._job.completed_fraction()
             with open(submit_log, "a") as submit_file:
                 submit_file.write("%s\n" % str((task_ids, submit_info)))
 

--- a/sisyphus/job.py
+++ b/sisyphus/job.py
@@ -1219,6 +1219,12 @@ class Job(metaclass=JobSingleton):
         """
         pass
 
+    def completed_fraction(self) -> Optional[float]:
+        """
+        :return: fraction between 0 and 1 or None if not available
+        """
+        return None
+
     @classmethod
     def hash(cls, parsed_args: Dict[str, Any]) -> str:
         """

--- a/sisyphus/task.py
+++ b/sisyphus/task.py
@@ -397,8 +397,12 @@ class Task:
                         # used to avoid wrongly marking jobs as interrupted do to slow filesystem updates
                         elif self.running(task_id):
                             return gs.STATE_RUNNING
-                        history = [] if engine is None else engine.get_submit_history(self)
-                        if history and len(history[task_id]) > gs.MAX_SUBMIT_RETRIES:
+                        history = [] if engine is None else engine.get_submit_history(self)[task_id]
+                        # Filter entries with less progress than the most recent entry.
+                        # https://github.com/rwth-i6/sisyphus/issues/295
+                        completed_fraction = (history[-1].get("completed_fraction") or 0) if history else 0
+                        history = [d for d in history if (d.get("completed_fraction") or 0) >= completed_fraction]
+                        if len(history) > gs.MAX_SUBMIT_RETRIES:
                             # More then three tries to run this task, something is wrong
                             return gs.STATE_RETRY_ERROR
                         else:


### PR DESCRIPTION
Fix #295

---

I'm specifically thinking about the new RWTH HPC situation that they mostly prefer jobs to run not longer than 24h, so it means I will need potentially lots of restarts. But I don't just want to increase `MAX_SUBMIT_RETRIES` to a random high number. I don't want that it tries to resubmit jobs that don't proceed. So that is why I want specifically to reset this counter when some epoch was trained, so that I can keep a low `MAX_SUBMIT_RETRIES`.

If you are affected by this, make sure you update Sisyphus to the latest version which now includes this PR, and also i6_core which contains an updated `ReturnnTrainingJob`, which implements `completed_fraction`.

And in your Sisyphus `settings.py`, you likely already have `check_engine_limits`. Modify the time clipping there like this:
```python
def check_engine_limits(current_rqmt, task):
    current_rqmt["time"] = min(23.99, current_rqmt.get("time", 2))
    ...
    return current_rqmt
```
