### PR TITLE
Some fixes for SLURM and SGE engine

### DIFF
--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -50,6 +50,10 @@ class EngineBase:
     def get_default_rqmt(self, task):
         raise NotImplementedError
 
+    def get_task_termination_info(self, task, task_id, submit_info):
+        """Return engine-provided usage information for a terminated task."""
+        return {}
+
     def get_used_engine(self, engine_selector):
         return self
 
@@ -103,7 +107,8 @@ class EngineBase:
                 for key, value in rqmt.items()
             }
             if update:
-                rqmt = task.update_rqmt(rqmt, task_id)
+                termination_info = self.get_task_termination_info(task, task_id, last_rqmt)
+                rqmt = task.update_rqmt(rqmt, task_id, additional_usage=termination_info)
 
         if "mem" in rqmt:
             rqmt["mem"] = tools.str_to_GB(rqmt["mem"])
@@ -328,6 +333,9 @@ class EngineSelector(EngineBase):
 
     def get_default_rqmt(self, task):
         return self.get_used_engine_by_rqmt(task.rqmt()).get_default_rqmt(task)
+
+    def get_task_termination_info(self, task, task_id, submit_info):
+        return self.get_used_engine_by_rqmt(submit_info).get_task_termination_info(task, task_id, submit_info)
 
     def get_job_node_hostnames(self):
         raise Exception(

--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -92,9 +92,16 @@ class EngineBase:
         # find last requirements
         rqmt = self.add_defaults_to_rqmt(task, rqmt)
         rqmt_hist = self.get_submit_history(task)[task_id]
-        if rqmt_hist and rqmt_hist[0] == rqmt:
-            # job has been submitted before and the rqmt given by the recipe did not change
-            rqmt.update(rqmt_hist[-1])
+        if rqmt_hist:
+            # Keep previously submitted values for requirements that did not change in the recipe. Build the result
+            # from the currently known requirement keys so that submit metadata and removed requirements are ignored.
+            missing = object()
+            initial_rqmt = rqmt_hist[0]
+            last_rqmt = rqmt_hist[-1]
+            rqmt = {
+                key: last_rqmt.get(key, value) if initial_rqmt.get(key, missing) == value else value
+                for key, value in rqmt.items()
+            }
             if update:
                 rqmt = task.update_rqmt(rqmt, task_id)
 

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -123,13 +123,15 @@ def update_engine_rqmt(last_rqmt: Dict, last_usage: Dict):
     # Did we run out of time?
     requested_time = last_rqmt.get("time")
     used_time = last_usage.get("used_time", 0)
-    if requested_time and requested_time - used_time < 0.1:
+    out_of_time = last_usage.get("out_of_time")
+    if requested_time and (out_of_time or requested_time - used_time < 0.1):
         out["time"] = requested_time * 2
 
     # Did it (nearly) break the memory limits?
     requested_memory = last_rqmt.get("mem")
     used_memory = last_usage.get("max", {}).get("rss", 0)
-    if requested_memory and last_usage.get("out_of_memory") or requested_memory - used_memory < 0.25:
+    out_of_memory = last_usage.get("out_of_memory")
+    if requested_memory and (out_of_memory or requested_memory - used_memory < 0.25):
         out["mem"] = requested_memory * 2
 
     return out

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -63,6 +63,7 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
                                           running jobs anymore.
         """
         self._task_info_cache_last_update = 0
+        self._task_info_cache = defaultdict(list)
         self.gateway = gateway
         self.default_rqmt = default_rqmt
         self.has_memory_resource = has_memory_resource
@@ -229,14 +230,14 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
             else:
                 # this id doesn't fit pattern, this should only happen if only parts of the jobs are restarted
                 job_id = self.submit_helper(call, logpath, rqmt, name, task_name, start_id, end_id, step_size)
-                submitted.append((list(range(start_id, end_id, step_size)), job_id))
+                submitted.append((list(range(start_id, end_id + 1, step_size)), job_id))
                 start_id, end_id, step_size = (task_id, None, None)
         assert start_id is not None
         if end_id is None:
             end_id = start_id
             step_size = 1
         job_id = self.submit_helper(call, logpath, rqmt, name, task_name, start_id, end_id, step_size)
-        submitted.append((list(range(start_id, end_id, step_size)), job_id))
+        submitted.append((list(range(start_id, end_id + 1, step_size)), job_id))
         return ENGINE_NAME, submitted
 
     def submit_helper(self, call, logpath, rqmt, name, task_name, start_id, end_id, step_size):
@@ -296,10 +297,10 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
                 # reset cache, after error
                 self.reset_cache()
             else:
-                job_id = sout[3].decode().split(".")
+                job_id = sout[3].decode().split(".")[0]
 
                 logging.info("Submitted with job_id: %s %s" % (job_id, name))
-                for task_id in range(start_id, end_id, step_size):
+                for task_id in range(start_id, end_id + 1, step_size):
                     self._task_info_cache[(name, task_id)].append((job_id, "PENDING"))
 
                 if err:

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -1,5 +1,5 @@
 # Author: Wilfried Michel <michel@cs.rwth-aachen.de>
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from collections import defaultdict, namedtuple
 from enum import Enum
 import getpass  # used to get username
@@ -325,6 +325,38 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
 
     def reset_cache(self):
         self._task_info_cache_last_update = -10
+
+    def get_task_termination_info(self, task, task_id, submit_info) -> Dict[str, bool]:
+        job_id = next(
+            (job_id for task_ids, job_id in submit_info.get("engine_info", []) if task_id in task_ids),
+            None,
+        )
+        if job_id is None:
+            return {}
+
+        slurm_task_id = f"{job_id}_{task_id}"
+        command = ["sacct", "-n", "-P", "-j", slurm_task_id, "--format=State%30"]
+        try:
+            out, err, retval = self.system_call(command)
+        except (OSError, subprocess.TimeoutExpired):
+            logging.warning(self._system_call_error_warn_msg(command))
+            return {}
+        if retval != 0:
+            logging.warning(self._system_call_error_warn_msg(command, err=err))
+            return {}
+
+        termination_info = {}
+        for raw_line in out:
+            state = raw_line.decode("utf-8").strip()
+            if not state:
+                logging.warning("Failed to parse sacct output: %s" % raw_line.decode("utf-8", errors="replace"))
+                continue
+            if state == "OUT_OF_MEMORY":
+                termination_info["out_of_memory"] = True
+            elif state == "TIMEOUT":
+                termination_info["out_of_time"] = True
+
+        return termination_info
 
     def queue_state(self):
         """Returns list with all currently running tasks in this queue"""

--- a/sisyphus/son_of_grid_engine.py
+++ b/sisyphus/son_of_grid_engine.py
@@ -66,6 +66,7 @@ class SonOfGridEngine(EngineBase):
                             The default "mpi" is somewhat arbitrarily chosen as we have it in our environment.
         """
         self._task_info_cache_last_update = 0
+        self._task_info_cache = defaultdict(list)
         self.gateway = gateway
         self.default_rqmt = default_rqmt
         self.auto_clean_eqw = auto_clean_eqw
@@ -225,14 +226,14 @@ class SonOfGridEngine(EngineBase):
             else:
                 # this id doesn't fit pattern, this should only happen if only parts of the jobs are restarted
                 job_id = self.submit_helper(call, logpath, rqmt, name, task_name, start_id, end_id, step_size)
-                submitted.append((list(range(start_id, end_id, step_size)), job_id))
+                submitted.append((list(range(start_id, end_id + 1, step_size)), job_id))
                 start_id, end_id, step_size = (task_id, None, None)
         assert start_id is not None
         if end_id is None:
             end_id = start_id
             step_size = 1
         job_id = self.submit_helper(call, logpath, rqmt, name, task_name, start_id, end_id, step_size)
-        submitted.append((list(range(start_id, end_id, step_size)), job_id))
+        submitted.append((list(range(start_id, end_id + 1, step_size)), job_id))
         return ENGINE_NAME, submitted
 
     def submit_helper(self, call, logpath, rqmt, name, task_name, start_id, end_id, step_size):
@@ -289,7 +290,7 @@ class SonOfGridEngine(EngineBase):
                 job_id = sjob_id[0]
 
                 logging.info("Submitted with job_id: %s %s" % (job_id, name))
-                for task_id in range(start_id, end_id, step_size):
+                for task_id in range(start_id, end_id + 1, step_size):
                     self._task_info_cache[(name, task_id)].append((job_id, "qw"))
 
                 if False:  # for debugging

--- a/sisyphus/task.py
+++ b/sisyphus/task.py
@@ -452,7 +452,7 @@ class Task:
             start = (chunk_size + 1) * overflow + chunk_size * (task_id - 1 - overflow)
             return range(start, start + chunk_size)
 
-    def update_rqmt(self, last_rqmt, task_id):
+    def update_rqmt(self, last_rqmt, task_id, additional_usage=None):
         """Update task requirements of interrupted job"""
         last_rqmt = last_rqmt.copy()
         # Make sure mem and time are numbers and not str
@@ -461,9 +461,15 @@ class Task:
         usage_file = self._job._sis_path(gs.PLOGGING_FILE + "." + self.name(), task_id, abspath=True)
 
         try:
-            last_usage = literal_eval(open(usage_file).read())
+            with open(usage_file) as usage_file_handle:
+                last_usage = literal_eval(usage_file_handle.read())
         except (SyntaxError, IOError):
-            # we don't know anything if no usage file is writen or is invalid, just reuse last rqmts
+            last_usage = {}
+
+        if additional_usage:
+            last_usage.update(additional_usage)
+        if not last_usage:
+            # We don't know anything if no usage information is available, so just reuse the last requirements.
             return last_rqmt
         return self._update_rqmt(last_rqmt=last_rqmt, last_usage=last_usage)
 


### PR DESCRIPTION
While working on the engine for a different project, my LLM pointed out some problems:

* SLURMs `job_id` is a `list[str]` instead of a single `str` as it is for all other engines
* Off-by-one error in the range that specifies which task ids have been submitted. In sbatch `end_id` is inclusive, for range it is exclusive.
* The check if a jobs rqmt has been updated is broken since we add a bunch of other stuff to the submit_history so `rqmt_hist[0] == rqmt` is never true. Instead, I now compare if `rqmt_hist[0]` is a subset of current rqmt and if not only update the changed keys.

This changes the content of `submit_log.<task>.<id>` but since we don't use this file for anything anyway, I decided against including compatibillity code. 

before
```
([1], {'cpu': 1, 'mem': 10.0, 'gpu': 0, 'time': 1.0, 'sbatch_args': [], 'engine_info': [([], ['26316813'])], 'engine_name': 'slurm', 'completed_fraction': None})
```

now 
```
([1], {'cpu': 1, 'mem': 10.0, 'gpu': 0, 'time': 1.0, 'sbatch_args': [], 'engine_info': [([1], '26316813')], 'engine_name': 'slurm', 'completed_fraction': None})
```
(note the changed `engine_info`)