### PR TITLE
fix automatic doubling of OOM / time rqmts

### DIFF
--- a/sisyphus/engine.py
+++ b/sisyphus/engine.py
@@ -50,6 +50,10 @@ class EngineBase:
     def get_default_rqmt(self, task):
         raise NotImplementedError
 
+    def get_task_termination_info(self, task, task_id, submit_info):
+        """Return engine-provided usage information for a terminated task."""
+        return {}
+
     def get_used_engine(self, engine_selector):
         return self
 
@@ -103,7 +107,8 @@ class EngineBase:
                 for key, value in rqmt.items()
             }
             if update:
-                rqmt = task.update_rqmt(rqmt, task_id)
+                termination_info = self.get_task_termination_info(task, task_id, last_rqmt)
+                rqmt = task.update_rqmt(rqmt, task_id, additional_usage=termination_info)
 
         if "mem" in rqmt:
             rqmt["mem"] = tools.str_to_GB(rqmt["mem"])
@@ -328,6 +333,9 @@ class EngineSelector(EngineBase):
 
     def get_default_rqmt(self, task):
         return self.get_used_engine_by_rqmt(task.rqmt()).get_default_rqmt(task)
+
+    def get_task_termination_info(self, task, task_id, submit_info):
+        return self.get_used_engine_by_rqmt(submit_info).get_task_termination_info(task, task_id, submit_info)
 
     def get_job_node_hostnames(self):
         raise Exception(

--- a/sisyphus/global_settings.py
+++ b/sisyphus/global_settings.py
@@ -123,13 +123,15 @@ def update_engine_rqmt(last_rqmt: Dict, last_usage: Dict):
     # Did we run out of time?
     requested_time = last_rqmt.get("time")
     used_time = last_usage.get("used_time", 0)
-    if requested_time and requested_time - used_time < 0.1:
+    out_of_time = last_usage.get("out_of_time")
+    if requested_time and (out_of_time or requested_time - used_time < 0.1):
         out["time"] = requested_time * 2
 
     # Did it (nearly) break the memory limits?
     requested_memory = last_rqmt.get("mem")
     used_memory = last_usage.get("max", {}).get("rss", 0)
-    if requested_memory and last_usage.get("out_of_memory") or requested_memory - used_memory < 0.25:
+    out_of_memory = last_usage.get("out_of_memory")
+    if requested_memory and (out_of_memory or requested_memory - used_memory < 0.25):
         out["mem"] = requested_memory * 2
 
     return out

--- a/sisyphus/simple_linux_utility_for_resource_management_engine.py
+++ b/sisyphus/simple_linux_utility_for_resource_management_engine.py
@@ -1,5 +1,5 @@
 # Author: Wilfried Michel <michel@cs.rwth-aachen.de>
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from collections import defaultdict, namedtuple
 from enum import Enum
 import getpass  # used to get username
@@ -325,6 +325,38 @@ class SimpleLinuxUtilityForResourceManagementEngine(EngineBase):
 
     def reset_cache(self):
         self._task_info_cache_last_update = -10
+
+    def get_task_termination_info(self, task, task_id, submit_info) -> Dict[str, bool]:
+        job_id = next(
+            (job_id for task_ids, job_id in submit_info.get("engine_info", []) if task_id in task_ids),
+            None,
+        )
+        if job_id is None:
+            return {}
+
+        slurm_task_id = f"{job_id}_{task_id}"
+        command = ["sacct", "-n", "-P", "-j", slurm_task_id, "--format=State%30"]
+        try:
+            out, err, retval = self.system_call(command)
+        except (OSError, subprocess.TimeoutExpired):
+            logging.warning(self._system_call_error_warn_msg(command))
+            return {}
+        if retval != 0:
+            logging.warning(self._system_call_error_warn_msg(command, err=err))
+            return {}
+
+        termination_info = {}
+        for raw_line in out:
+            state = raw_line.decode("utf-8").strip()
+            if not state:
+                logging.warning("Failed to parse sacct output: %s" % raw_line.decode("utf-8", errors="replace"))
+                continue
+            if state == "OUT_OF_MEMORY":
+                termination_info["out_of_memory"] = True
+            elif state == "TIMEOUT":
+                termination_info["out_of_time"] = True
+
+        return termination_info
 
     def queue_state(self):
         """Returns list with all currently running tasks in this queue"""

--- a/sisyphus/task.py
+++ b/sisyphus/task.py
@@ -452,7 +452,7 @@ class Task:
             start = (chunk_size + 1) * overflow + chunk_size * (task_id - 1 - overflow)
             return range(start, start + chunk_size)
 
-    def update_rqmt(self, last_rqmt, task_id):
+    def update_rqmt(self, last_rqmt, task_id, additional_usage=None):
         """Update task requirements of interrupted job"""
         last_rqmt = last_rqmt.copy()
         # Make sure mem and time are numbers and not str
@@ -461,9 +461,15 @@ class Task:
         usage_file = self._job._sis_path(gs.PLOGGING_FILE + "." + self.name(), task_id, abspath=True)
 
         try:
-            last_usage = literal_eval(open(usage_file).read())
+            with open(usage_file) as usage_file_handle:
+                last_usage = literal_eval(usage_file_handle.read())
         except (SyntaxError, IOError):
-            # we don't know anything if no usage file is writen or is invalid, just reuse last rqmts
+            last_usage = {}
+
+        if additional_usage:
+            last_usage.update(additional_usage)
+        if not last_usage:
+            # We don't know anything if no usage information is available, so just reuse the last requirements.
             return last_rqmt
         return self._update_rqmt(last_rqmt=last_rqmt, last_usage=last_usage)
 


### PR DESCRIPTION
This PR depends on #306 

Today I want to re-enable the feature of the old SGE days that if a Job (goes OOM or runs out of time) and is resumable, its failing rqmt is doubled before resubmission.

We currently have the heuristics `requested_time - used_time < 0.1` and `requested_memory - used_memory < 0.25` and additionally the `LoggingThread` can set the `"out_of_memory"` flag. This has worked in the past but recently under SLURM we see that OOM / OOT are not detected reliably (or, well, at all).

In slurm we can querry `sacct` about a termination reason. So I propose to add a `get_task_termination_info` function to `EngineBase` which by default does nothing and returns empty dict, but SLURMEngine checks sacct and sets `"out_of_memory"` and/or `"out_of_time"` accordingly.

Tested on the AppTek cluster:
```
([1], {'cpu': 1, 'mem': 1.0, 'gpu': 0, 'time': 0.05, 'sbatch_args': [], 'engine_info': [([1], '26316812')], 'engine_name': 'slurm', 'completed_fraction': None})
([1], {'cpu': 1, 'mem': 1.0, 'gpu': 0, 'time': 0.1, 'sbatch_args': [], 'engine_info': [([1], '26316822')], 'engine_name': 'slurm', 'completed_fraction': None})
([1], {'cpu': 1, 'mem': 1.0, 'gpu': 0, 'time': 0.2, 'sbatch_args': [], 'engine_info': [([1], '26316828')], 'engine_name': 'slurm', 'completed_fraction': None})
([1], {'cpu': 1, 'mem': 1.0, 'gpu': 0, 'time': 0.4, 'sbatch_args': [], 'engine_info': [([1], '26316835')], 'engine_name': 'slurm', 'completed_fraction': None})
```
and 
```
([1], {'cpu': 1, 'mem': 0.5, 'gpu': 0, 'time': 1.0, 'sbatch_args': [], 'engine_info': [([1], '26316816')], 'engine_name': 'slurm', 'completed_fraction': None})
([1], {'cpu': 1, 'mem': 1.0, 'gpu': 0, 'time': 1.0, 'sbatch_args': [], 'engine_info': [([1], '26316818')], 'engine_name': 'slurm', 'completed_fraction': None})
([1], {'cpu': 1, 'mem': 2.0, 'gpu': 0, 'time': 1.0, 'sbatch_args': [], 'engine_info': [([1], '26316820')], 'engine_name': 'slurm', 'completed_fraction': None})
```