### PR TITLE
Add tk.running_in_manager(), set for manager and console

### DIFF
--- a/sisyphus/__main__.py
+++ b/sisyphus/__main__.py
@@ -14,6 +14,7 @@ from sisyphus.manager import manager
 from sisyphus.helper import console
 from sisyphus import shortcuts
 import sisyphus.global_settings as gs
+import sisyphus.toolkit
 
 # Setup logging
 import logging
@@ -162,6 +163,7 @@ def main():
     # add argv to config_files if manager or console is called
     if args.func in [manager, console]:
         args.config_files += args.argv
+        sisyphus.toolkit._sis_running_in_manager = True
 
     # Setup logging colors
     sisyphus.logging_format.add_coloring_to_logging()

--- a/sisyphus/toolkit.py
+++ b/sisyphus/toolkit.py
@@ -284,6 +284,14 @@ def running_in_worker():
     return _sis_running_in_worker
 
 
+_sis_running_in_manager = False
+
+
+def running_in_manager():
+    """Returns true if this code is run inside the manager or console"""
+    return _sis_running_in_manager
+
+
 # Helper functions mainly used in the console
 def load_job(path: str) -> Job:
     """Load job from job directory even if it is already cleaned up


### PR DESCRIPTION
Add a running_in_manager() function to tell whether the code is running in the manager or runtime. Added because the counterpart running_in_worker() would return False in a Returnn training job, where RETURNN runs in a new Python subprocess where Sisyphus is imported again.